### PR TITLE
Image builders

### DIFF
--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -94,8 +94,9 @@ upload-aws:
 		   -e 's/%AWS_BUCKET_DIR%/$(AWS_BUCKET_DIR)/g' \
 		   /tmp/$(IMAGE_NAME).json
 	aws --region $(AWS_REGION) s3 cp $(VM_DIR)/$(IMAGE_NAME).raw s3://$(AWS_BUCKET)/$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw
-	aws ec2 import-image --architecture x86_64 \
+	$(eval IMPORT_TASK := $(shell aws ec2 import-image --architecture x86_64 \
 		--description "$(IMAGE_NAME)" \
-		--disk-containers /tmp/$(IMAGE_NAME).json \
+		--disk-containers "/tmp/$(IMAGE_NAME).json" \
 		--platform Linux \
-		--license-type BYOL
+		--license-type BYOL))
+	$(eval AMI_IMPORT_TASK_ID := $(shell echo $(IMPORT_TASK) | jq -r '.ImportTaskId')

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -22,7 +22,7 @@ QEMU_IMG_BIN=$(VM_DIR)/qemu-img
 XML=domain.xml
 XML_RENDERED=$(IMAGE_NAME).xml
 
-all: setup build prepare convert upload
+azure: setup build prepare upload-azure
 
 setup:
 	[ -d $(VM_DIR)/converted ] || mkdir -p $(VM_DIR)/converted
@@ -42,3 +42,28 @@ prepare:
 	[ -f $(VM_DIR)/$(IMAGE_NAME).qcow2 ] || exit
 	@echo "Preparing $(IMAGE_NAME)"
 	virt-sysprep -a $(VM_DIR)/$(IMAGE_NAME).qcow2
+	@echo "Sparsifying $(IMAGE_NAME)"
+	virt-sparsify --tmp $(VM_DIR)/tmp \
+		--compress --format qcow2 \
+		$(VM_DIR)/$(IMAGE_NAME).qcow2 \
+		$(VM_DIR)/converted/$(IMAGE_NAME).qcow2
+
+upload-azure:
+	@echo "Converting $(IMAGE_NAME) to RAW format"
+	$(QEMU_IMG_BIN) convert -f qcow2 -O raw \
+		$(VM_DIR)/converted/$(IMAGE_NAME).qcow2 \
+		$(VM_DIR)/$(IMAGE_NAME).raw
+	@echo "Converting $(IMAGE_NAME) to VHD format"
+	$(QEMU_IMG_BIN) convert -f raw -O vpc -o subformat=fixed,force_size \
+		$(VM_DIR)/$(IMAGE_NAME).raw \
+		$(VM_DIR)/$(IMAGE_NAME).vhd
+	@echo "Uploading $(IMAGE_NAME) to $(AZURE_IMAGE_URL)"
+	az storage blob upload --account-name $(AZURE_STORAGE_ACCOUNT) \
+		--container-name $(AZURE_STORAGE_CONTAINER) \
+		--type page \
+		--file $(VM_DIR)/$(IMAGE_NAME).vhd \
+		--name $(IMAGE_NAME).vhd
+	az image create --resource-group $(AZURE_RESOURCE_GROUP) \
+	  	--location uksouth \
+	    --os-type Linux \
+	   	--source $(AZURE_IMAGE_URL)

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -31,7 +31,7 @@ AWS_REGION=eu-west-1
 AZURE_STORAGE_ACCOUNT=alcescloudware
 AZURE_STORAGE_CONTAINER=images
 AZURE_RESOURCE_GROUP=alces-cloudware
-AZURE_IMAGE_URL="https://$(STORAGE_ACCOUNT).blob.core.windows.net/$(AZURE_STORAGE_CONTAINER)/$(IMAGE_NAME).vhd"
+AZURE_IMAGE_URL="https://$(AZURE_STORAGE_ACCOUNT).blob.core.windows.net/$(AZURE_STORAGE_CONTAINER)/$(IMAGE_NAME).vhd"
 
 image: setup build prepare upload
 

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -58,7 +58,6 @@ prepare:
 		--compress --format qcow2 \
 		$(VM_DIR)/$(IMAGE_NAME).qcow2 \
 		$(VM_DIR)/converted/$(IMAGE_NAME).qcow2
-	@echo "Run upload-$(PLATFORM) to continue"
 
 upload:
 	if [ $(PLATFORM) = "aws" ]; then $(MAKE) upload-aws; fi

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -23,6 +23,9 @@ XML=domain.xml
 XML_RENDERED=$(IMAGE_NAME).xml
 
 # AWS config
+AWS_BUCKET=alces-cloudware
+AWS_BUCKET_DIR=images
+AWS_REGION=eu-west-1
 
 # Azure config
 AZURE_STORAGE_ACCOUNT=alces-cloudware
@@ -30,7 +33,7 @@ AZURE_STORAGE_CONTAINER=images
 AZURE_RESOURCE_GROUP=alces-cloudware
 AZURE_IMAGE_URL="https://$(STORAGE_ACCOUNT).blob.core.windows.net/$(AZURE_STORAGE_CONTAINER)/$(IMAGE_NAME).vhd"
 
-azure: setup build prepare upload-azure
+image: setup build prepare
 
 setup:
 	[ -d $(VM_DIR)/converted ] || mkdir -p $(VM_DIR)/converted
@@ -55,6 +58,7 @@ prepare:
 		--compress --format qcow2 \
 		$(VM_DIR)/$(IMAGE_NAME).qcow2 \
 		$(VM_DIR)/converted/$(IMAGE_NAME).qcow2
+	@echo "Run upload-$(PLATFORM) to continue"
 
 upload-azure:
 	@echo "Converting $(IMAGE_NAME) to RAW format"
@@ -75,3 +79,15 @@ upload-azure:
 	  	--location uksouth \
 	    --os-type Linux \
 	   	--source $(AZURE_IMAGE_URL)
+
+upload-aws:
+	$(QEMU_IMG_BIN) convert -f qcow2 -O raw \
+		$(VM_DIR)/converted/$(IMAGE_NAME).qcow2 \
+		$(VM_DIR)/$(IMAGE_NAME).raw
+	aws --region $(AWS_REGION) s3 cp $(VM_DIR)/$(IMAGE_NAME).raw s3://$(AWS_BUCKET)/$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw
+	jo Description="$(IMAGE_NAME)" Format="raw" UserBucket="$$(jo S3Bucket="$(AWS_BUCKET)" S3Key="$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw")" > /tmp/$(IMAGE_NAME).json
+	aws ec2 import-image --architecture x86_64 \
+		--description "$(IMAGE_NAME)" \
+		--disk-containers /tmp/$(IMAGE_NAME).json \
+		--platform Linux \
+		--license-type BYOL

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -33,7 +33,7 @@ AZURE_STORAGE_CONTAINER=images
 AZURE_RESOURCE_GROUP=alces-cloudware
 AZURE_IMAGE_URL="https://$(STORAGE_ACCOUNT).blob.core.windows.net/$(AZURE_STORAGE_CONTAINER)/$(IMAGE_NAME).vhd"
 
-image: setup build prepare
+image: setup build prepare upload
 
 setup:
 	[ -d $(VM_DIR)/converted ] || mkdir -p $(VM_DIR)/converted
@@ -59,6 +59,10 @@ prepare:
 		$(VM_DIR)/$(IMAGE_NAME).qcow2 \
 		$(VM_DIR)/converted/$(IMAGE_NAME).qcow2
 	@echo "Run upload-$(PLATFORM) to continue"
+
+upload:
+	if [ $(PLATFORM) = "aws" ]; then $(MAKE) upload-aws; fi
+	if [ $(PLATFORM) = "azure" ]; then $(MAKE) upload-azure; fi
 
 upload-azure:
 	@echo "Converting $(IMAGE_NAME) to RAW format"

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -8,7 +8,7 @@
 # Image config
 PLATFORM=azure # default to azure
 IMAGE_TYPE=alces-cloudware-base
-IMAGE_VERSION=2018.1-alpha
+IMAGE_VERSION=2018.2.1
 IMAGE_NAME=$(IMAGE_TYPE)-$(IMAGE_VERSION)-$(PLATFORM)
 
 # Libvirt/Oz config

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -28,7 +28,7 @@ AWS_BUCKET_DIR=images
 AWS_REGION=eu-west-1
 
 # Azure config
-AZURE_STORAGE_ACCOUNT=alces-cloudware
+AZURE_STORAGE_ACCOUNT=alcescloudware
 AZURE_STORAGE_CONTAINER=images
 AZURE_RESOURCE_GROUP=alces-cloudware
 AZURE_IMAGE_URL="https://$(STORAGE_ACCOUNT).blob.core.windows.net/$(AZURE_STORAGE_CONTAINER)/$(IMAGE_NAME).vhd"

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -88,7 +88,7 @@ upload-aws:
 		$(VM_DIR)/converted/$(IMAGE_NAME).qcow2 \
 		$(VM_DIR)/$(IMAGE_NAME).raw
 	aws --region $(AWS_REGION) s3 cp $(VM_DIR)/$(IMAGE_NAME).raw s3://$(AWS_BUCKET)/$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw
-	echo "{"Description":"$(IMAGE_NAME)","Format":"raw","UserBucket":{"S3Bucket":"$(AWS_BUCKET)","S3Key":"$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw"}}" > /tmp/$(IMAGE_NAME).json
+	echo "{\"Description\":\"$(IMAGE_NAME)\",\"Format\":\"raw\",\"UserBucket\":{\"S3Bucket\":\"$(AWS_BUCKET)\",\"S3Key\":\"$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw\"}}" > /tmp/$(IMAGE_NAME).json
 	aws ec2 import-image --architecture x86_64 \
 		--description "$(IMAGE_NAME)" \
 		--disk-containers /tmp/$(IMAGE_NAME).json \

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -38,7 +38,7 @@ image: setup build prepare upload
 setup:
 	[ -d $(VM_DIR)/converted ] || mkdir -p $(VM_DIR)/converted
 	[ -d $(VM_DIR)/tmp ] || mkdir -p $(VM_DIR)/tmp
-	[ -f $(QEMU_IMG_BIN) ] || echo "$(QEMU_IMG_BIN) not present" && exit
+	[ -f $(QEMU_IMG_BIN) ] || exit
 
 build:
 	cp -v $(TDL) $(TDL_RENDERED)
@@ -94,9 +94,8 @@ upload-aws:
 		   -e 's/%AWS_BUCKET_DIR%/$(AWS_BUCKET_DIR)/g' \
 		   /tmp/$(IMAGE_NAME).json
 	aws --region $(AWS_REGION) s3 cp $(VM_DIR)/$(IMAGE_NAME).raw s3://$(AWS_BUCKET)/$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw
-	$(eval IMPORT_TASK := $(shell aws ec2 import-image --architecture x86_64 \
+	aws ec2 import-image --architecture x86_64 \
 		--description "$(IMAGE_NAME)" \
-		--disk-containers "/tmp/$(IMAGE_NAME).json" \
+		--disk-containers "file:///tmp/$(IMAGE_NAME).json" \
 		--platform Linux \
-		--license-type BYOL))
-	$(eval AMI_IMPORT_TASK_ID := $(shell echo $(IMPORT_TASK) | jq -r '.ImportTaskId')
+		--license-type BYOL

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -88,8 +88,12 @@ upload-aws:
 	$(QEMU_IMG_BIN) convert -f qcow2 -O raw \
 		$(VM_DIR)/converted/$(IMAGE_NAME).qcow2 \
 		$(VM_DIR)/$(IMAGE_NAME).raw
+	cp container.json /tmp/$(IMAGE_NAME).json
+	sed -i -e 's/%IMAGE_NAME%/$(IMAGE_NAME)/g' \
+	       -e 's/%AWS_BUCKET_NAME%/$(AWS_BUCKET)/g' \
+		   -e 's/%AWS_BUCKET_DIR%/$(AWS_BUCKET_DIR)/g' \
+		   /tmp/$(IMAGE_NAME).json
 	aws --region $(AWS_REGION) s3 cp $(VM_DIR)/$(IMAGE_NAME).raw s3://$(AWS_BUCKET)/$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw
-	echo "{\"Description\":\"$(IMAGE_NAME)\",\"Format\":\"raw\",\"UserBucket\":{\"S3Bucket\":\"$(AWS_BUCKET)\",\"S3Key\":\"$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw\"}}" > /tmp/$(IMAGE_NAME).json
 	aws ec2 import-image --architecture x86_64 \
 		--description "$(IMAGE_NAME)" \
 		--disk-containers /tmp/$(IMAGE_NAME).json \

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -7,8 +7,8 @@
 #==============================================================================
 # Image config
 PLATFORM=azure # default to azure
-IMAGE_TYPE="alces-cloudware-base"
-IMAGE_VERSION="2018.1-alpha"
+IMAGE_TYPE=alces-cloudware-base
+IMAGE_VERSION=2018.1-alpha
 IMAGE_NAME=$(IMAGE_TYPE)-$(IMAGE_VERSION)-$(PLATFORM)
 
 # Libvirt/Oz config

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -33,7 +33,7 @@ build:
 	cp -v $(TDL) $(TDL_RENDERED)
 	cp -v $(KICKSTART) $(KICKSTART_RENDERED)
 	sed -i -e 's,c7,$(IMAGE_NAME),g' $(TDL_RENDERED)
-	sed -i -e 's,%BUILD_RELEASE%,$(IMAGE_VERSION),g' $(KS_RENDERED)
+	sed -i -e 's,%BUILD_RELEASE%,$(IMAGE_VERSION),g' $(KICKSTART_RENDERED)
 	@echo "Building image $(IMAGE_NAME)"
 	oz-install -d3 -u $(TDL_RENDERED) -x /tmp/$(IMAGE_NAME).xml \
 				   -p -a $(KICKSTART_RENDERED) -c $(OZ_CFG) -t 1800

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -88,7 +88,7 @@ upload-aws:
 		$(VM_DIR)/converted/$(IMAGE_NAME).qcow2 \
 		$(VM_DIR)/$(IMAGE_NAME).raw
 	aws --region $(AWS_REGION) s3 cp $(VM_DIR)/$(IMAGE_NAME).raw s3://$(AWS_BUCKET)/$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw
-	jo Description="$(IMAGE_NAME)" Format="raw" UserBucket="$$(jo S3Bucket="$(AWS_BUCKET)" S3Key="$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw")" > /tmp/$(IMAGE_NAME).json
+	echo "{"Description":"$(IMAGE_NAME)","Format":"raw","UserBucket":{"S3Bucket":"$(AWS_BUCKET)","S3Key":"$(AWS_BUCKET_DIR)/$(IMAGE_NAME).raw"}}" > /tmp/$(IMAGE_NAME).json
 	aws ec2 import-image --architecture x86_64 \
 		--description "$(IMAGE_NAME)" \
 		--disk-containers /tmp/$(IMAGE_NAME).json \

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -1,0 +1,44 @@
+#==============================================================================
+# Copyright (C) 2018 Stephen F Norledge & Alces Software Ltd.
+#
+# This file is part of Alces Cloudware.
+#
+# Some rights reserved, see LICENSE.
+#==============================================================================
+# Image config
+PLATFORM=azure # default to azure
+IMAGE_TYPE="alces-cloudware-base"
+IMAGE_VERSION="2018.1-alpha"
+IMAGE_NAME=$(IMAGE_TYPE)-$(IMAGE_VERSION)-$(PLATFORM)
+
+# Libvirt/Oz config
+KICKSTART=$(IMAGE_TYPE)-$(PLATFORM).ks
+KICKSTART_RENDERED=/tmp/$(IMAGE_NAME).ks
+TDL=centos7.tdl
+TDL_RENDERED=/tmp/$(IMAGE_NAME).tdl
+OZ_CFG=oz.cfg
+VM_DIR=/mnt/resource
+QEMU_IMG_BIN=$(VM_DIR)/qemu-img
+XML=domain.xml
+XML_RENDERED=$(IMAGE_NAME).xml
+
+all: setup build prepare convert upload
+
+setup:
+	[ -d $(VM_DIR)/converted ] || mkdir -p $(VM_DIR)/converted
+	[ -d $(VM_DIR)/tmp ] || mkdir -p $(VM_DIR)/tmp
+	[ -f $(QEMU_IMG_BIN) ] || echo "$(QEMU_IMG_BIN) not present" && exit
+
+build:
+	cp -v $(TDL) $(TDL_RENDERED)
+	cp -v $(KICKSTART) $(KICKSTART_RENDERED)
+	sed -i -e 's,c7,$(IMAGE_NAME),g' $(TDL_RENDERED)
+	sed -i -e 's,%BUILD_RELEASE%,$(IMAGE_VERSION),g' $(KS_RENDERED)
+	@echo "Building image $(IMAGE_NAME)"
+	oz-install -d3 -u $(TDL_RENDERED) -x /tmp/$(IMAGE_NAME).xml \
+				   -p -a $(KICKSTART_RENDERED) -c $(OZ_CFG) -t 1800
+
+prepare:
+	[ -f $(VM_DIR)/$(IMAGE_NAME).qcow2 ] || exit
+	@echo "Preparing $(IMAGE_NAME)"
+	virt-sysprep -a $(VM_DIR)/$(IMAGE_NAME).qcow2

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -22,6 +22,14 @@ QEMU_IMG_BIN=$(VM_DIR)/qemu-img
 XML=domain.xml
 XML_RENDERED=$(IMAGE_NAME).xml
 
+# AWS config
+
+# Azure config
+AZURE_STORAGE_ACCOUNT=alces-cloudware
+AZURE_STORAGE_CONTAINER=images
+AZURE_RESOURCE_GROUP=alces-cloudware
+AZURE_IMAGE_URL="https://$(STORAGE_ACCOUNT).blob.core.windows.net/$(AZURE_STORAGE_CONTAINER)/$(IMAGE_NAME).vhd"
+
 azure: setup build prepare upload-azure
 
 setup:

--- a/support/build/Makefile
+++ b/support/build/Makefile
@@ -79,6 +79,7 @@ upload-azure:
 		--file $(VM_DIR)/$(IMAGE_NAME).vhd \
 		--name $(IMAGE_NAME).vhd
 	az image create --resource-group $(AZURE_RESOURCE_GROUP) \
+		--name $(IMAGE_NAME) \
 	  	--location uksouth \
 	    --os-type Linux \
 	   	--source $(AZURE_IMAGE_URL)

--- a/support/build/README.md
+++ b/support/build/README.md
@@ -1,0 +1,106 @@
+# Building Cloudware images
+
+Notes on building and using Cloudware images on various platforms
+
+## Prerequisites
+
+- Standard Alces Libvirt host setup
+- Large amount of disk space
+- AWS/Azure command-line tools installed
+
+## General usage
+
+The `Makefile` contains all build steps to build, prepare and upload an image to each available Cloud provider. Images are built using Oz and the approrpriate kickstart file for the provider. 
+
+### Configuration
+
+There are a few notable config settings, including:
+
+- `PLATFORM` - The platform to build an image for, e.g. `aws` or `azure`
+- `IMAGE_VERSION` - Set the image version to create
+- `VM_DIR` - Set the VM dir, this should have enough space to create the image 
+
+## AWS
+
+### Configuration
+
+In order to create an AWS image, the client running Cloudware should meet the following prerequisites:
+
+- AWS command-line tools installed
+- AWS credentials configured
+- S3 bucket with folder for images to be stored in
+- AWS IAM role for VM Import/Export created
+
+There are also a couple of config options in `Makefile`, which are important to set correctly:
+
+- `AWS_BUCKET` - The S3 bucket name the image(s) are to be stored in
+- `AWS_BUCKET_DIR` - The folder within the S3 bucket
+- `AWS_REGION` - The region the S3 bucket is created in, and also the destination region for the created image
+
+### Building an image
+
+Once the configuration and prerequisites are met - creating, preparing and uploading an image is as simple as running:
+
+```bash
+make image PLATFORM=aws
+```
+
+### Post-build tasks
+
+The final stage of the build process will output some JSON, displaying the VM import task ID, and the resulting AMI ID for the given region:
+
+```json
+{
+    "Status": "active",
+    "LicenseType": "BYOL",
+    "Description": "alces-cloudware-base-2018.2.1-aws",
+    "Platform": "Linux",
+    "Architecture": "x86_64",
+    "SnapshotDetails": [
+        {
+            "UserBucket": {
+                "S3Bucket": "alces-cloudware",
+                "S3Key": "images/alces-cloudware-base-2018.2.1-aws.raw"
+            },
+            "DiskImageSize": 0.0,
+            "Format": "RAW"
+        }
+    ],
+    "Progress": "2",
+    "StatusMessage": "pending",
+    "ImportTaskId": "import-ami-fgrxv97s"
+}
+```
+
+The new AMI in the above example will be `ami-fgrxv97s`. You can then copy this AMI round to other regions if required. 
+
+The AMI ID also needs to be updated in the provider templates, located in `providers/aws/templates/`
+
+## Azure
+
+### Configuration
+
+In order to create an Azure image, the client running Cloudware should meet the following prerequisites:
+
+- Azure command-line tools installed
+- Azure credentials configured
+- Resource Group with storage account created
+- Storage container created inside the storage account
+
+There are also a couple of config options in `Makefile`, which are important to set correctly:
+
+- `AZURE_STORAGE_ACCOUNT` - The name of the storage account
+- `AZURE_STORAGE_CONTAINER` - Name of the storage container created within the storage account
+- `AZURE_RESOURCE_GROUP` - The name of the resource group containing the storage account
+
+### Building an image
+
+Once the configuration and prerequisites are met - creating, preparing and uploading an image is as simple as running:
+
+```bash
+make image PLATFORM=azure
+```
+
+### Post-build tasks
+
+Once the image has been created, the image reference needs to be updated in the Azure Cloudware templates located in `providers/azure/templates`.

--- a/support/build/alces-cloudware-base-aws.ks
+++ b/support/build/alces-cloudware-base-aws.ks
@@ -1,6 +1,5 @@
 auth --enableshadow --passalgo=sha512
 reboot
-url --url="mirror.centos.org/centos/7/os/x86_64"
 firewall --enabled --service=ssh
 firstboot --disable
 ignoredisk --only-use=vda

--- a/support/build/alces-cloudware-base-aws.ks
+++ b/support/build/alces-cloudware-base-aws.ks
@@ -102,6 +102,13 @@ EOL
 # make sure firstboot doesn't start
 echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
 
+# write Cloudware version file
+cat << EOF > /etc/cloudware.yml
+---
+image:
+  version: '%BUILD_RELEASE%'
+EOF
+
 yum clean all
 
 # XXX instance type markers - MUST match CentOS Infra expectation

--- a/support/build/alces-cloudware-base-aws.ks
+++ b/support/build/alces-cloudware-base-aws.ks
@@ -1,0 +1,172 @@
+auth --enableshadow --passalgo=sha512
+reboot
+url --url="mirror.centos.org/centos/7/os/x86_64"
+firewall --enabled --service=ssh
+firstboot --disable
+ignoredisk --only-use=vda
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+repo --name "os" --baseurl="http://mirror.centos.org/centos/7/os/x86_64/" --cost=100
+repo --name "updates" --baseurl="http://mirror.centos.org/centos/7/updates/x86_64/" --cost=100
+repo --name "extras" --baseurl="http://mirror.centos.org/centos/7/extras/x86_64/" --cost=100
+# Network information
+network  --bootproto=dhcp
+network  --hostname=localhost.localdomain
+# Root password
+rootpw --iscrypted thereisnopasswordanditslocked
+selinux --enforcing
+services --disabled="kdump" --enabled="network,sshd,rsyslog,chronyd"
+timezone UTC --isUtc
+# Disk
+bootloader --append="console=tty0" --location=mbr --timeout=1 --boot-drive=vda
+zerombr
+clearpart --all --initlabel 
+part / --fstype="xfs" --ondisk=vda --size=4096 --grow
+
+%post --erroronfail
+passwd -d root
+passwd -l root
+
+# pvgrub support
+echo -n "Creating grub.conf for pvgrub"
+rootuuid=$( awk '$2=="/" { print $1 };'  /etc/fstab )
+mkdir /boot/grub
+echo -e 'default=0\ntimeout=0\n\n' > /boot/grub/grub.conf
+for kv in $( ls -1v /boot/vmlinuz* |grep -v rescue |sed s/.*vmlinuz-//  ); do
+  echo "title CentOS Linux 7 ($kv)" >> /boot/grub/grub.conf
+  echo -e "\troot (hd0)" >> /boot/grub/grub.conf
+  echo -e "\tkernel /boot/vmlinuz-$kv ro root=$rootuuid console=hvc0 LANG=en_US.UTF-8" >> /boot/grub/grub.conf
+  echo -e "\tinitrd /boot/initramfs-$kv.img" >> /boot/grub/grub.conf
+  echo
+done
+ln -sf grub.conf /boot/grub/menu.lst
+ln -sf /boot/grub/grub.conf /etc/grub.conf
+
+# setup systemd to boot to the right runlevel
+rm -f /etc/systemd/system/default.target
+ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
+echo .
+
+yum -C -y remove linux-firmware
+
+# Remove firewalld; it is required to be present for install/image building.
+# but we dont ship it in cloud
+yum -C -y remove firewalld --setopt="clean_requirements_on_remove=1"
+yum -C -y remove avahi\* Network\*
+sed -i '/^#NAutoVTs=.*/ a\
+NAutoVTs=0' /etc/systemd/logind.conf
+
+cat > /etc/sysconfig/network << EOF
+NETWORKING=yes
+NOZEROCONF=yes
+EOF
+
+# For cloud images, 'eth0' _is_ the predictable device name, since
+# we don't want to be tied to specific virtual (!) hardware
+rm -f /etc/udev/rules.d/70*
+ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
+
+# simple eth0 config, again not hard-coded to the build hardware
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+USERCTL="yes"
+PEERDNS="yes"
+IPV6INIT="no"
+PERSISTENT_DHCLIENT="1"
+EOF
+
+echo "virtual-guest" > /etc/tuned/active_profile
+
+# generic localhost names
+cat > /etc/hosts << EOF
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+EOF
+echo .
+
+systemctl mask tmp.mount
+
+cat <<EOL > /etc/sysconfig/kernel
+# UPDATEDEFAULT specifies if new-kernel-pkg should make
+# new kernels the default
+UPDATEDEFAULT=yes
+
+# DEFAULTKERNEL specifies the default kernel package type
+DEFAULTKERNEL=kernel
+EOL
+
+# make sure firstboot doesn't start
+echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
+
+yum clean all
+
+# XXX instance type markers - MUST match CentOS Infra expectation
+echo 'genclo' > /etc/yum/vars/infra
+
+# chance dhcp client retry/timeouts to resolve #6866
+cat  >> /etc/dhcp/dhclient.conf << EOF
+
+timeout 300;
+retry 60;
+EOF
+
+echo "Fixing SELinux contexts."
+touch /var/log/cron
+touch /var/log/boot.log
+mkdir -p /var/cache/yum
+/usr/sbin/fixfiles -R -a restore
+
+# reorder console entries
+sed -i 's/console=tty0/console=tty0 console=ttyS0,115200n8/' /boot/grub2/grub.cfg
+
+%end
+
+%packages
+@core
+chrony
+cloud-init
+cloud-utils-growpart
+dracut-config-generic
+dracut-norescue
+firewalld
+grub2
+kernel
+nfs-utils
+rsync
+tar
+yum-utils
+-NetworkManager
+-aic94xx-firmware
+-alsa-firmware
+-alsa-lib
+-alsa-tools-firmware
+-biosdevname
+-iprutils
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6000g2b-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+-libertas-sd8686-firmware
+-libertas-sd8787-firmware
+-libertas-usb8388-firmware
+-plymouth
+
+%end

--- a/support/build/alces-cloudware-base-azure.ks
+++ b/support/build/alces-cloudware-base-azure.ks
@@ -122,6 +122,13 @@ EOF
 systemctl enable cloud-init
 systemctl enable waagent
 
+# write Cloudware version file
+cat << EOF > /etc/cloudware.yml
+---
+image:
+  version: '%BUILD_RELEASE%'
+EOF
+
 ###################################################################
 # Cleanup
 ###################################################################

--- a/support/build/alces-cloudware-base-azure.ks
+++ b/support/build/alces-cloudware-base-azure.ks
@@ -1,0 +1,194 @@
+auth --enableshadow --passalgo=sha512
+reboot
+firewall --enabled --service=ssh
+firstboot --disable
+ignoredisk --only-use=vda
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+repo --name "os" --baseurl="http://mirror.centos.org/centos/7/os/x86_64/" --cost=100
+repo --name "updates" --baseurl="http://mirror.centos.org/centos/7/updates/x86_64/" --cost=100
+repo --name "extras" --baseurl="http://mirror.centos.org/centos/7/extras/x86_64/" --cost=100
+# Network information
+network  --bootproto=dhcp
+network  --hostname=localhost.localdomain
+# Root password
+rootpw alcesflightonazure
+selinux --enforcing
+services --disabled="kdump" --enabled="network,sshd,rsyslog,chronyd"
+timezone UTC --isUtc
+# Disk
+bootloader --append="console=tty0" --location=mbr --timeout=1 --boot-drive=vda
+zerombr
+clearpart --all --initlabel
+part / --fstype="xfs" --ondisk=vda --size=4096 --grow
+
+%post --erroronfail
+
+# setup systemd to boot to the right runlevel
+rm -f /etc/systemd/system/default.target
+ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
+
+yum -C -y remove linux-firmware
+
+# Remove firewalld; it is required to be present for install/image building.
+# but we dont ship it in cloud
+yum -C -y remove firewalld --setopt="clean_requirements_on_remove=1"
+yum -C -y remove avahi\* Network\*
+sed -i '/^#NAutoVTs=.*/ a\
+NAutoVTs=0' /etc/systemd/logind.conf
+
+cat > /etc/sysconfig/network << EOF
+NETWORKING=yes
+NOZEROCONF=yes
+EOF
+
+rm -f /etc/udev/rules.d/70*
+ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
+
+# simple eth0 config, again not hard-coded to the build hardware
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+USERCTL="yes"
+PEERDNS="yes"
+IPV6INIT="no"
+PERSISTENT_DHCLIENT="1"
+EOF
+
+echo "virtual-guest" > /etc/tuned/active_profile
+
+# generic localhost names
+cat > /etc/hosts << EOF
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+EOF
+echo .
+
+systemctl mask tmp.mount
+
+cat <<EOL > /etc/sysconfig/kernel
+# UPDATEDEFAULT specifies if new-kernel-pkg should make
+# new kernels the default
+UPDATEDEFAULT=yes
+
+# DEFAULTKERNEL specifies the default kernel package type
+DEFAULTKERNEL=kernel
+EOL
+
+# Disable selinux
+sed -e 's/^SELINUX=.*/SELINUX=disabled/g' -i /etc/selinux/config
+
+# Prep sudo
+sed -e "s/Defaults    requiretty/#Defaults    requiretty/g" -i /etc/sudoers
+
+# Lock/scramble root password
+dd if=/dev/urandom count=50|md5sum|passwd --stdin root
+passwd -l root
+
+# make sure firstboot doesn't start
+echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
+
+yum -y install WALinuxAgent cloud-init
+cat << EOF > /etc/waagent.conf
+#
+# Microsoft Azure Linux Agent Configuration
+#
+Provisioning.Enabled=n
+Provisioning.UseCloudInit=y
+Provisioning.DeleteRootPassword=n
+Provisioning.RegenerateSshHostKeyPair=y
+Provisioning.SshHostKeyPairType=rsa
+Provisioning.MonitorHostName=y
+Provisioning.DecodeCustomData=n
+Provisioning.ExecuteCustomData=n
+Provisioning.AllowResetSysUser=n
+ResourceDisk.Format=y
+ResourceDisk.Filesystem=ext4
+ResourceDisk.MountPoint=/mnt/resource
+ResourceDisk.EnableSwap=y
+ResourceDisk.SwapSizeMB=16384
+ResourceDisk.MountOptions=None
+Logs.Verbose=n
+OS.RootDeviceScsiTimeout=300
+OS.OpensslPath=None
+OS.SshDir=/etc/ssh
+OS.EnableFirewall=n
+EOF
+
+systemctl enable cloud-init
+systemctl enable waagent
+
+###################################################################
+# Cleanup
+###################################################################
+
+yum clean all
+
+# XXX instance type markers - MUST match CentOS Infra expectation
+echo 'azure' > /etc/yum/vars/infra
+
+# chance dhcp client retry/timeouts to resolve #6866
+cat  >> /etc/dhcp/dhclient.conf << EOF
+
+timeout 300;
+retry 60;
+EOF
+
+echo "Fixing SELinux contexts."
+touch /var/log/cron
+touch /var/log/boot.log
+mkdir -p /var/cache/yum
+/usr/sbin/fixfiles -R -a restore
+
+# reorder console entries
+sed -i 's/console=tty0/console=tty0 console=ttyS0,115200n8/' /boot/grub2/grub.cfg
+
+%end
+
+%packages
+@core
+chrony
+WALinuxAgent
+dracut-config-generic
+dracut-norescue
+firewalld
+grub2
+kernel
+nfs-utils
+rsync
+tar
+yum-utils
+-NetworkManager
+-aic94xx-firmware
+-alsa-firmware
+-alsa-lib
+-alsa-tools-firmware
+-biosdevname
+-iprutils
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6000g2b-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+-libertas-sd8686-firmware
+-libertas-sd8787-firmware
+-libertas-usb8388-firmware
+-plymouth
+
+%end

--- a/support/build/centos7.tdl
+++ b/support/build/centos7.tdl
@@ -1,0 +1,16 @@
+<template version="1.0">
+  <name>c7</name>
+  <disk>
+    <size>32</size>
+  </disk>
+  <os>
+    <name>CentOS-7</name>
+    <version>0</version>
+    <arch>x86_64</arch>
+    <install type='iso'>
+      <iso>http://mirror.ox.ac.uk/sites/mirror.centos.org/7/isos/x86_64/CentOS-7-x86_64-DVD-1708.iso</iso>
+    </install>
+  </os>
+  <description>CentOS 7 Base Install</description>
+</template>
+

--- a/support/build/container.json
+++ b/support/build/container.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Description": "%IMAGE_NAME%",
+    "Format": "raw",
+    "UserBucket": {
+      "S3Bucket": "%AWS_BUCKET_NAME%",
+      "S3Key": "%AWS_BUCKET_DIR%/%IMAGE_NAME%.raw"
+    }
+  }
+]

--- a/support/build/oz.cfg
+++ b/support/build/oz.cfg
@@ -1,0 +1,20 @@
+[paths]
+output_dir = /opt/vm
+data_dir = /var/lib/oz
+screenshot_dir = /var/lib/oz/screenshots
+
+[libvirt]
+uri = qemu:///system
+image_type = qcow2
+bridge_name = virbr0
+cpus = 2
+memory = 4096
+
+[cache]
+original_mwdia = yes
+modified_media = no
+jeos = no
+
+[icicle]
+safe_generation = no
+


### PR DESCRIPTION
This PR introduces image builders for both the currently available platforms (AWS and Azure). 

Fixes #6 and #7 

As per our existing image build process, this should be done on a correctly configured Libvirt host. 

The current process is (needs improvement):

* Build and upload the images

```
make image PLATFORM=aws
make image PLATFORM=azure
```

* Update the image references in templates (manual step, could be automated) in `providers/<provider>/templates/`