### PR TITLE
Add `state` to `machine list` output

### DIFF
--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -200,20 +200,15 @@ module Cloudware
         raise('No available machines') if m.list.nil?
         Whirly.stop
         m.list.each do |_k, v|
-          if options.domain
-            if v[:domain] == options.domain
-              r << [v[:name], v[:domain], v[:role], v[:prv_ip], v[:mgt_ip], v[:type]]
-            end
-          else
-            r << [v[:name], v[:domain], v[:role], v[:prv_ip], v[:mgt_ip], v[:type]]
-          end
+          r << [v[:name], v[:domain], v[:role], v[:prv_ip], v[:mgt_ip], v[:type], v[:state]]
         end
         table = Terminal::Table.new headings: ['Name'.bold,
                                                'Domain'.bold,
                                                'Role'.bold,
                                                'Prv IP address'.bold,
                                                'Mgt IP address'.bold,
-                                               'Type'.bold],
+                                               'Type'.bold,
+                                               'State'.bold],
                                     rows: r
         puts table
       end


### PR DESCRIPTION
Quick fix to display machine `state` when running `machine list`. Also remove some dodgy code - that looking back I have no clue why I ever wrote. 