### PR TITLE
Disable source/destination checking on master instances, enabling a

### DIFF
--- a/providers/aws/templates/machine-master.yml
+++ b/providers/aws/templates/machine-master.yml
@@ -193,6 +193,7 @@ Resources:
       ImageId: !FindInMap ["RegionMap", !Ref "AWS::Region", "AMI"]
       InstanceType: !Ref vmType
       Monitoring: true
+      SourceDestCheck: false,
       KeyName: !Ref keyPairName
       NetworkInterfaces:
         -

--- a/providers/aws/templates/machine-master.yml
+++ b/providers/aws/templates/machine-master.yml
@@ -193,7 +193,7 @@ Resources:
       ImageId: !FindInMap ["RegionMap", !Ref "AWS::Region", "AMI"]
       InstanceType: !Ref vmType
       Monitoring: true
-      SourceDestCheck: false,
+      SourceDestCheck: false
       KeyName: !Ref keyPairName
       NetworkInterfaces:
         -


### PR DESCRIPTION
`master` instance type to act as a gateway for instances that do not
have a public IP address, and can therefore not access the Internet