### PR TITLE
Clean up the `Config` and the use of `Whirly`

### DIFF
--- a/lib/cloudware/aws.rb
+++ b/lib/cloudware/aws.rb
@@ -52,7 +52,7 @@ module Cloudware
     def load_config(region)
       if valid_credentials?
         log.debug("[#{self.class}] Loading credentials from config file")
-        credentials = Credentials.new(config.aws_access_key_id, config.aws_secret_access_key)
+        credentials = Credentials.new(config.aws.access_key_id, config.aws.secret_access_key)
         @cfn = CloudFormation::Client.new(region: region, credentials: credentials)
         @ec2 = EC2::Client.new(region: region, credentials: credentials)
       else
@@ -64,7 +64,7 @@ module Cloudware
     end
 
     def valid_credentials?
-      !config.aws_access_key_id.nil? || !config.aws_secret_access_key.nil?
+      !config.aws.access_key_id.nil? || !config.aws.secret_access_key.nil?
     end
 
     def regions

--- a/lib/cloudware/azure.rb
+++ b/lib/cloudware/azure.rb
@@ -43,17 +43,17 @@ module Cloudware
     def options
       @options ||= begin
         provider = MsRestAzure::ApplicationTokenProvider.new(
-          config.azure_tenant_id,
-          config.azure_client_id,
-          config.azure_client_secret
+          config.azure.tenant_id,
+          config.azure.client_id,
+          config.azure.client_secret
         )
         credentials = MsRest::TokenCredentials.new(provider)
         @options = {
           credentials: credentials,
-          subscription_id: config.azure_subscription_id.to_s,
-          tenant_id: config.azure_tenant_id.to_s,
-          client_id: config.azure_client_id.to_s,
-          client_secret: config.azure_client_secret.to_s,
+          subscription_id: config.azure.subscription_id.to_s,
+          tenant_id: config.azure.tenant_id.to_s,
+          client_id: config.azure.client_id.to_s,
+          client_secret: config.azure.client_secret.to_s,
         }
         @options
       end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -24,7 +24,7 @@ module Cloudware
           options.mgtsubnetcidr = ask('Mgt subnet CIDR: ') if options.mgtsubnetcidr.nil?
           d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
 
-          Whirly.start spinner: 'dots2', status: 'Verifying network CIDR is valid'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Verifying network CIDR is valid'.bold
           raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
           Whirly.status = 'Verifying prv subnet CIDR is valid'.bold
           raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
@@ -32,18 +32,18 @@ module Cloudware
           raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           Whirly.stop
 
-          Whirly.start spinner: 'dots2', status: 'Checking domain name is valid'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Checking domain name is valid'.bold
           raise("Domain name #{options.name} is not valid") unless d.valid_name?
           Whirly.stop
 
-          Whirly.start spinner: 'dots2', status: 'Checking domain does not already exist'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Checking domain does not already exist'.bold
           raise("Domain name #{options.name} already exists") if d.exists?
           d.provider = options.provider.to_s
           Whirly.status = 'Verifying provider is valid'.bold
           raise("Provider #{options.provider} does not exist") unless d.valid_provider?
           Whirly.stop
 
-          Whirly.start spinner: 'dots2', status: 'Creating new deployment'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Creating new deployment'.bold
           d.create
           Whirly.stop
         end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -24,26 +24,26 @@ module Cloudware
           options.mgtsubnetcidr = ask('Mgt subnet CIDR: ') if options.mgtsubnetcidr.nil?
           d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
 
-          Whirly.start status: 'Verifying network CIDR is valid'.bold
+          Whirly.start status: 'Verifying network CIDR is valid'
           raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
-          Whirly.status = 'Verifying prv subnet CIDR is valid'.bold
+          Whirly.status = 'Verifying prv subnet CIDR is valid'
           raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
-          Whirly.status = 'Verifying mgt subnet CIDR is valid'.bold
+          Whirly.status = 'Verifying mgt subnet CIDR is valid'
           raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           Whirly.stop
 
-          Whirly.start status: 'Checking domain name is valid'.bold
+          Whirly.start status: 'Checking domain name is valid'
           raise("Domain name #{options.name} is not valid") unless d.valid_name?
           Whirly.stop
 
-          Whirly.start status: 'Checking domain does not already exist'.bold
+          Whirly.start status: 'Checking domain does not already exist'
           raise("Domain name #{options.name} already exists") if d.exists?
           d.provider = options.provider.to_s
-          Whirly.status = 'Verifying provider is valid'.bold
+          Whirly.status = 'Verifying provider is valid'
           raise("Provider #{options.provider} does not exist") unless d.valid_provider?
           Whirly.stop
 
-          Whirly.start status: 'Creating new deployment'.bold
+          Whirly.start status: 'Creating new deployment'
           d.create
           Whirly.stop
         end

--- a/lib/cloudware/commands/domain/destroy.rb
+++ b/lib/cloudware/commands/domain/destroy.rb
@@ -10,11 +10,11 @@ module Cloudware
           options.name = ask('Domain name: ') if options.name.nil?
           d.name = options.name.to_s
 
-          Whirly.start spinner: 'dots2', status: 'Checking domain exists'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Checking domain exists'.bold
           raise("Domain name #{options.name} does not exist") unless d.exists?
           Whirly.stop
 
-          Whirly.start spinner: 'dots2', status: "Destroying domain #{options.name}".bold, stop: '[OK]'.green
+          Whirly.start status: "Destroying domain #{options.name}".bold
           d.destroy
           Whirly.stop
         end

--- a/lib/cloudware/commands/domain/destroy.rb
+++ b/lib/cloudware/commands/domain/destroy.rb
@@ -10,11 +10,11 @@ module Cloudware
           options.name = ask('Domain name: ') if options.name.nil?
           d.name = options.name.to_s
 
-          Whirly.start status: 'Checking domain exists'.bold
+          Whirly.start status: 'Checking domain exists'
           raise("Domain name #{options.name} does not exist") unless d.exists?
           Whirly.stop
 
-          Whirly.start status: "Destroying domain #{options.name}".bold
+          Whirly.start status: "Destroying domain #{options.name}"
           d.destroy
           Whirly.stop
         end

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -16,7 +16,7 @@ module Cloudware
           end
 
           r = []
-          Whirly.start spinner: 'dots2', status: 'Fetching available domains'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Fetching available domains'.bold
           raise('No available domains') if d.list.nil?
           Whirly.stop
           d.list.each do |k, v|

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -16,7 +16,7 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available domains'.bold
+          Whirly.start status: 'Fetching available domains'
           raise('No available domains') if d.list.nil?
           Whirly.stop
           d.list.each do |k, v|

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,19 +29,19 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          Whirly.start status: 'Verifying domain exists'.bold
+          Whirly.start status: 'Verifying domain exists'
           raise("Domain #{options.domain} does not exist") unless m.valid_domain?
           Whirly.stop
 
-          Whirly.start status: 'Checking machine name is valid'.bold
+          Whirly.start status: 'Checking machine name is valid'
           raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
-          Whirly.status = 'Verifying prv IP address'.bold
+          Whirly.status = 'Verifying prv IP address'
           raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
-          Whirly.status = 'Verifying mgt IP address'.bold
+          Whirly.status = 'Verifying mgt IP address'
           raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
           Whirly.stop
 
-          Whirly.start status: 'Creating new deployment'.bold
+          Whirly.start status: 'Creating new deployment'
           m.create
           Whirly.stop
         end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,11 +29,11 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          Whirly.start spinner: 'dots2', status: 'Verifying domain exists'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Verifying domain exists'.bold
           raise("Domain #{options.domain} does not exist") unless m.valid_domain?
           Whirly.stop
 
-          Whirly.start spinner: 'dots2', status: 'Checking machine name is valid'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Checking machine name is valid'.bold
           raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
           Whirly.status = 'Verifying prv IP address'.bold
           raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
@@ -41,7 +41,7 @@ module Cloudware
           raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
           Whirly.stop
 
-          Whirly.start spinner: 'dots2', status: 'Creating new deployment'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Creating new deployment'.bold
           m.create
           Whirly.stop
         end

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -13,11 +13,11 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           m.domain = options.domain.to_s
 
-          Whirly.start status: 'Checking machine exists'.bold
+          Whirly.start status: 'Checking machine exists'
           raise('Machine does not exist') unless m.exists?
           Whirly.stop
 
-          Whirly.start status: "Destroying #{options.name} in domain #{options.domain}".bold
+          Whirly.start status: "Destroying #{options.name} in domain #{options.domain}"
           m.destroy
           Whirly.stop
         end

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -13,11 +13,11 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           m.domain = options.domain.to_s
 
-          Whirly.start spinner: 'dots2', status: 'Checking machine exists'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Checking machine exists'.bold
           raise('Machine does not exist') unless m.exists?
           Whirly.stop
 
-          Whirly.start spinner: 'dots2', status: "Destroying #{options.name} in domain #{options.domain}".bold, stop: '[OK]'.green
+          Whirly.start status: "Destroying #{options.name} in domain #{options.domain}".bold
           m.destroy
           Whirly.stop
         end

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -15,7 +15,7 @@ module Cloudware
           case options.output.to_s
           when 'table'
             table = Terminal::Table.new do |t|
-              Whirly.start spinner: 'dots2', status: 'Fetching machine info'.bold, stop: '[OK]'.green
+              Whirly.start status: 'Fetching machine info'.bold
               t.add_row ['Machine name'.bold, m.name]
               t.add_row ['Domain name'.bold, m.get_item('domain')]
               t.add_row ['Machine role'.bold, m.get_item('role')]

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -15,7 +15,7 @@ module Cloudware
           case options.output.to_s
           when 'table'
             table = Terminal::Table.new do |t|
-              Whirly.start status: 'Fetching machine info'.bold
+              Whirly.start status: 'Fetching machine info'
               t.add_row ['Machine name'.bold, m.name]
               t.add_row ['Domain name'.bold, m.get_item('domain')]
               t.add_row ['Machine role'.bold, m.get_item('role')]

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -14,7 +14,7 @@ module Cloudware
           end
 
           r = []
-          Whirly.start spinner: 'dots2', status: 'Fetching available machines'.bold, stop: '[OK]'.green
+          Whirly.start status: 'Fetching available machines'.bold
           raise('No available machines') if m.list.nil?
           Whirly.stop
           m.list.each do |_k, v|

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -14,7 +14,7 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available machines'.bold
+          Whirly.start status: 'Fetching available machines'
           raise('No available machines') if m.list.nil?
           Whirly.stop
           m.list.each do |_k, v|

--- a/lib/cloudware/commands/machine/power/off.rb
+++ b/lib/cloudware/commands/machine/power/off.rb
@@ -13,7 +13,7 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering off machine #{options.name}".bold
+            Whirly.start status: "Powering off machine #{options.name}"
             machine.power_off
             Whirly.stop
           end

--- a/lib/cloudware/commands/machine/power/off.rb
+++ b/lib/cloudware/commands/machine/power/off.rb
@@ -13,7 +13,7 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start spinner: 'dots2', status: "Powering off machine #{options.name}".bold, stop: '[OK]'.green
+            Whirly.start status: "Powering off machine #{options.name}".bold
             machine.power_off
             Whirly.stop
           end

--- a/lib/cloudware/commands/machine/power/on.rb
+++ b/lib/cloudware/commands/machine/power/on.rb
@@ -13,7 +13,7 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start spinner: 'dots2', status: "Powering on machine #{options.name}".bold, stop: '[OK]'.green
+            Whirly.start status: "Powering on machine #{options.name}".bold
             machine.power_on
             Whirly.stop
           end

--- a/lib/cloudware/commands/machine/power/on.rb
+++ b/lib/cloudware/commands/machine/power/on.rb
@@ -13,7 +13,7 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering on machine #{options.name}".bold
+            Whirly.start status: "Powering on machine #{options.name}"
             machine.power_on
             Whirly.stop
           end

--- a/lib/cloudware/commands/machine/rebuild.rb
+++ b/lib/cloudware/commands/machine/rebuild.rb
@@ -12,7 +12,7 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           machine.domain = options.domain.to_s
 
-          Whirly.start status: "Recreating machine #{options.name}".bold
+          Whirly.start status: "Recreating machine #{options.name}"
           machine.rebuild
           Whirly.stop
         end

--- a/lib/cloudware/commands/machine/rebuild.rb
+++ b/lib/cloudware/commands/machine/rebuild.rb
@@ -12,7 +12,7 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           machine.domain = options.domain.to_s
 
-          Whirly.start spinner: 'dots2', status: "Recreating machine #{options.name}".bold, stop: '[OK]'.green
+          Whirly.start status: "Recreating machine #{options.name}".bold
           machine.rebuild
           Whirly.stop
         end

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -32,7 +32,7 @@ module Cloudware
     attr_accessor :log_file, :azure, :aws, :providers
 
     def initialize
-      config = YAML.load_file(config_path) || raise("Couldn't load config file #{cfg_file}")
+      config = YAML.load_file(config_path)
 
       self.log_file = config['general']['log_file'] || log.error('Unable to load log_file')
 

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -23,6 +23,9 @@
 #==============================================================================
 require 'yaml'
 require 'ostruct'
+require 'whirly'
+
+Whirly.configure spinner: 'dots2', stop: '[OK]'.green
 
 module Cloudware
   class Config

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -22,52 +22,20 @@
 # https://github.com/alces-software/cloudware
 #==============================================================================
 require 'yaml'
+require 'ostruct'
 
 module Cloudware
   class Config
-    attr_accessor :log_file
-    attr_accessor :azure_tenant_id, :azure_subscription_id, :azure_client_secret, :azure_client_id
-    attr_accessor :aws_access_key_id, :aws_secret_access_key
-    attr_accessor :providers
+    attr_accessor :log_file, :azure, :aws, :providers
 
     def initialize
       config = YAML.load_file(config_path) || raise("Couldn't load config file #{cfg_file}")
 
       self.log_file = config['general']['log_file'] || log.error('Unable to load log_file')
 
-      # Provider: azure
-      self.azure_tenant_id = begin
-                               config['provider']['azure']['tenant_id']
-                             rescue StandardError
-                               nil
-                             end
-      self.azure_subscription_id = begin
-                                     config['provider']['azure']['subscription_id']
-                                   rescue StandardError
-                                     nil
-                                   end
-      self.azure_client_id = begin
-                               config['provider']['azure']['client_id']
-                             rescue StandardError
-                               nil
-                             end
-      self.azure_client_secret = begin
-                                   config['provider']['azure']['client_secret']
-                                 rescue StandardError
-                                   nil
-                                 end
-
-      # Provider: aws
-      self.aws_access_key_id = begin
-                                 config['provider']['aws']['access_key_id']
-                               rescue StandardError
-                                 nil
-                               end
-      self.aws_secret_access_key = begin
-                                     config['provider']['aws']['secret_access_key']
-                                   rescue StandardError
-                                     nil
-                                   end
+      # Providers
+      self.azure = OpenStruct.new(config['provider']['azure'])
+      self.aws = OpenStruct.new(config['provider']['aws'])
 
       # Providers List (identifying valid/present providers)
       self.providers = []


### PR DESCRIPTION
Based on #36, please merge it first.

There are two major changes in this PR. Firstly the `Config` does not unpack the config file for the `aws` and `azure` keys. This is a pain and makes the file needlessly complex. Instead the contents can be loaded as `OpenStructs` and then the keys become available. It might be worth adding some validation on the config files structure at some point.

The second thing is setting up the default `Whirly`. Instead of specifying the `Whirly` type each time, it is now done in the `Config`. This means that `Whirly` can now be directly used everywhere else.