### PR TITLE
Add FlightConnector Domain and Machine Templates

### DIFF
--- a/providers/aws/templates/domain0.yml
+++ b/providers/aws/templates/domain0.yml
@@ -19,7 +19,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'domain0', !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', !Ref cloudwareDomain, 'domain0']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -40,7 +40,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'domain0', !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', !Ref cloudwareDomain, 'domain0']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -65,7 +65,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'domain0', !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', !Ref cloudwareDomain, 'domain0']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId

--- a/providers/aws/templates/domain0.yml
+++ b/providers/aws/templates/domain0.yml
@@ -1,5 +1,5 @@
 ---
-Description: 'Flight Connector DomainU Template'
+Description: 'Flight Connector Domain0 Template'
 Parameters:
    cloudwareId:
      Type: String
@@ -19,7 +19,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', 'domain0', !Ref cloudwareDomain]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -40,7 +40,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', 'domain0', !Ref cloudwareDomain]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -65,7 +65,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', 'domain0', !Ref cloudwareDomain]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId

--- a/providers/aws/templates/domainU.yml
+++ b/providers/aws/templates/domainU.yml
@@ -20,7 +20,7 @@ Resources:
   Network:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: !Join ['', ['10.100.', !Ref clusterIndex, '0/24']]
+      CidrBlock: !Join ['', ['10.100.', !Ref clusterIndex, '.0/24']]
       EnableDnsSupport: true
       EnableDnsHostnames: true
       Tags:
@@ -35,10 +35,10 @@ Resources:
           Value: !Ref cloudwareDomain
         -
           Key: 'cloudware_network_cidr'
-          Value: !Join ['', ['10.100.', !Ref clusterIndex, '0/24']]
+          Value: !Join ['', ['10.100.', !Ref clusterIndex, '.0/24']]
         -
           Key: 'cloudware_prv_subnet_cidr'
-          Value: !Join ['', ['10.100.', !Ref clusterIndex, '0/24']]
+          Value: !Join ['', ['10.100.', !Ref clusterIndex, '.0/24']]
 
   InternetGateway:
     Type: AWS::EC2::InternetGateway
@@ -64,7 +64,7 @@ Resources:
   PrvSubnet:
     Type: AWS::EC2::Subnet
     Properties:
-      CidrBlock: !Join ['', ['10.100.', !Ref clusterIndex, '0/24']]
+      CidrBlock: !Join ['', ['10.100.', !Ref clusterIndex, '.0/24']]
       VpcId: !Ref Network
       AvailabilityZone: !Select
         - 0

--- a/providers/aws/templates/domainU.yml
+++ b/providers/aws/templates/domainU.yml
@@ -1,0 +1,101 @@
+---
+Description: 'Flight Connector DomainU Template'
+Parameters:
+   cloudwareId:
+     Type: String
+     Description: 'Enter the Cloudware UUID'
+
+   cloudwareDomain:
+     Type: String
+     Description: 'Enter the desired domain name'
+
+Resources:
+  Network:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.78.100.0/24
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+        -
+          Key: 'cloudware_network_cidr'
+          Value: '10.78.100.0/24'
+        -
+          Key: 'cloudware_prv_subnet_cidr'
+          Value: '10.78.100.0/24'
+  
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    DependsOn: Network
+    Properties:
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+  
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref Network
+  
+  PrvSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.78.100.0/24
+      VpcId: !Ref Network
+      AvailabilityZone: !Select
+        - 0
+        - Fn::GetAZs: !Ref 'AWS::Region'
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+  
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      VpcId: !Ref Network
+      Tags:
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+   
+  PrvSubnetRouteTableAssocation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrvSubnet
+      RouteTableId: !Ref RouteTable
+
+  RouteInternetGateway:
+    Type: AWS::EC2::Route
+    DependsOn: InternetGateway
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId: !Ref InternetGateway

--- a/providers/aws/templates/domainU.yml
+++ b/providers/aws/templates/domainU.yml
@@ -1,0 +1,101 @@
+---
+Description: 'Flight Connector DomainU Template'
+Parameters:
+   cloudwareId:
+     Type: String
+     Description: 'Enter the Cloudware UUID'
+
+   cloudwareDomain:
+     Type: String
+     Description: 'Enter the desired domain name'
+
+Resources:
+  Network:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.100.2.0/24
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+        -
+          Key: 'cloudware_network_cidr'
+          Value: '10.100.2.0/24'
+        -
+          Key: 'cloudware_prv_subnet_cidr'
+          Value: '10.100.2.0/24'
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    DependsOn: Network
+    Properties:
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref Network
+
+  PrvSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.100.2.0/24
+      VpcId: !Ref Network
+      AvailabilityZone: !Select
+        - 0
+        - Fn::GetAZs: !Ref 'AWS::Region'
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      VpcId: !Ref Network
+      Tags:
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+
+  PrvSubnetRouteTableAssocation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrvSubnet
+      RouteTableId: !Ref RouteTable
+
+  RouteInternetGateway:
+    Type: AWS::EC2::Route
+    DependsOn: InternetGateway
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId: !Ref InternetGateway

--- a/providers/aws/templates/domainU.yml
+++ b/providers/aws/templates/domainU.yml
@@ -26,7 +26,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', !Ref clusterDomain, !Join ['', ['cluster', !Ref clusterIndex]]]]
+          Value: !Join ['-', ['flightconnector', !Ref cloudwareDomain, !Join ['', ['cluster', !Ref clusterIndex]]]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -47,7 +47,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', !Ref clusterDomain, !Join ['', ['cluster', !Ref clusterIndex]]]]
+          Value: !Join ['-', ['flightconnector', !Ref cloudwareDomain, !Join ['', ['cluster', !Ref clusterIndex]]]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -72,7 +72,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', !Ref clusterDomain, !Join ['', ['cluster', !Ref clusterIndex]]]]
+          Value: !Join ['-', ['flightconnector', !Ref cloudwareDomain, !Join ['', ['cluster', !Ref clusterIndex]]]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId

--- a/providers/aws/templates/domainU.yml
+++ b/providers/aws/templates/domainU.yml
@@ -26,7 +26,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'cluster', !Ref clusterIndex, !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', !Ref clusterDomain, !Join ['', ['cluster', !Ref clusterIndex]]]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -47,7 +47,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'cluster', !Ref clusterIndex, !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', !Ref clusterDomain, !Join ['', ['cluster', !Ref clusterIndex]]]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -72,7 +72,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'cluster', !Ref clusterIndex, !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', !Ref clusterDomain, !Join ['', ['cluster', !Ref clusterIndex]]]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId

--- a/providers/aws/templates/domainU.yml
+++ b/providers/aws/templates/domainU.yml
@@ -9,17 +9,24 @@ Parameters:
      Type: String
      Description: 'Enter the desired domain name'
 
+   clusterIndex:
+     Type: Number
+     Description: 'Enter the cluster index'
+     Default: 1
+     MinValue: 1
+     MaxValue: 99
+
 Resources:
   Network:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: 10.100.2.0/24
+      CidrBlock: !Join ['', ['10.100.', !Ref clusterIndex, '0/24']]
       EnableDnsSupport: true
       EnableDnsHostnames: true
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', 'cluster', !Ref clusterIndex, !Ref cloudwareDomain]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -28,10 +35,10 @@ Resources:
           Value: !Ref cloudwareDomain
         -
           Key: 'cloudware_network_cidr'
-          Value: '10.100.2.0/24'
+          Value: !Join ['', ['10.100.', !Ref clusterIndex, '0/24']]
         -
           Key: 'cloudware_prv_subnet_cidr'
-          Value: '10.100.2.0/24'
+          Value: !Join ['', ['10.100.', !Ref clusterIndex, '0/24']]
 
   InternetGateway:
     Type: AWS::EC2::InternetGateway
@@ -40,7 +47,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', 'cluster', !Ref clusterIndex, !Ref cloudwareDomain]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -57,7 +64,7 @@ Resources:
   PrvSubnet:
     Type: AWS::EC2::Subnet
     Properties:
-      CidrBlock: 10.100.2.0/24
+      CidrBlock: !Join ['', ['10.100.', !Ref clusterIndex, '0/24']]
       VpcId: !Ref Network
       AvailabilityZone: !Select
         - 0
@@ -65,7 +72,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', ['flightconnector', 'domainU', !Ref cloudwareDomain]]
+          Value: !Join ['-', ['flightconnector', 'cluster', !Ref clusterIndex, !Ref cloudwareDomain]]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId

--- a/providers/aws/templates/machine-gateway.yml
+++ b/providers/aws/templates/machine-gateway.yml
@@ -52,6 +52,7 @@ Resources:
       GroupDescription: 'Flight Connector Gateway'
       VpcId: !Ref networkId
       SecurityGroupIngress:
+        -
           IpProtocol: 'tcp'
           FromPort: 22
           ToPort: 22

--- a/providers/aws/templates/machine-gateway.yml
+++ b/providers/aws/templates/machine-gateway.yml
@@ -17,10 +17,6 @@ Parameters:
     Type: String
     Description: 'Enter the prv subnet ID'
 
-  prvSubnetCidr:
-    Type: String
-    Description: 'Enter the prv subnet CIDR'
-
   keyPairName:
     Default: 'aws_ireland'
     Type: String
@@ -46,7 +42,6 @@ Mappings:
 Resources:
   securityGroupGateway:
     Type: AWS::EC2::SecurityGroup
-    DependsOn: RouteInternetGateway
     Properties:
       GroupName: !Join ['-', [!Ref cloudwareDomain, 'gateway']]
       GroupDescription: 'Flight Connector Gateway'
@@ -125,7 +120,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join [' ', [!Ref cloudwareDomain, 'gateway']
+          Value: !Join [' ', [!Ref cloudwareDomain, 'gateway']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId

--- a/providers/aws/templates/machine-gateway.yml
+++ b/providers/aws/templates/machine-gateway.yml
@@ -1,0 +1,156 @@
+---
+Description: 'FlightConnector Gateway Node Template'
+Parameters:
+  cloudwareId:
+    Type: String
+    Description: 'Enter the Cloudware UUID'
+
+  cloudwareDomain:
+    Type: String
+    Description: 'Enter the Cloudware domain name'
+
+  networkId:
+    Type: String
+    Description: 'Enter the VPC/network ID'
+
+  prvSubnetId:
+    Type: String
+    Description: 'Enter the prv subnet ID'
+
+  prvSubnetCidr:
+    Type: String
+    Description: 'Enter the prv subnet CIDR'
+
+  keyPairName:
+    Default: 'aws_ireland'
+    Type: String
+    Description: 'Select the AWS keypair to assign to the instance'
+
+  vmType:
+    Type: String
+    Description: 'Enter the size of the instance'
+
+  vmRole:
+    Type: String
+    Description: 'Enter the Cloudware instance type'
+
+  vmFlavour:
+    Type: String
+    Description: 'Enter the VM flavour'
+
+Mappings:
+  RegionMap:
+    eu-west-1:
+      "AMI": "ami-d266dfab"
+
+Resources:
+  securityGroupGateway:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: RouteInternetGateway
+    Properties:
+      GroupName: !Join ['-', [!Ref cloudwareDomain, 'gateway']]
+      GroupDescription: 'Flight Connector Gateway'
+      VpcId: !Ref networkId
+      SecurityGroupIngress:
+          IpProtocol: 'tcp'
+          FromPort: 22
+          ToPort: 22
+          CidrIp: '0.0.0.0/0'
+          Description: 'Allow inbound SSH access'
+        -
+          IpProtocol: 'icmp'
+          FromPort: '8'
+          ToPort: '-1'
+          CidrIp: '0.0.0.0/0'
+          Description: 'Allow ping'
+        - 
+          IpProtocol: 'tcp'
+          FromPort: 2005
+          ToPort: 2005
+          CidrIp: '0.0.0.0/0'
+          Description: 'Allow inbound cluster VPN access'
+      SecurityGroupEgress:
+        -
+          IpProtocol: '-1'
+          FromPort: 0
+          ToPort: 65535
+          CidrIp: '0.0.0.0/0'
+          Description: 'Allow outbound internet access'
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', [!Ref cloudwareDomain, 'gateway']]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+
+  prvInterface:
+    Type: AWS::EC2::NetworkInterface
+    Properties:
+      Description: !Join [' ', [!Ref cloudwareDomain, 'gateway', 'prv network interface']]
+      SourceDestCheck: false
+      GroupSet:
+        - !Ref securityGroupGateway
+      PrivateIpAddress: 10.78.100.10
+      SubnetId: !Ref prvSubnetId
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', [!Ref cloudwareDomain, 'gateway', 'prv']]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+
+  master:
+    Type: AWS::EC2::Instance
+    Properties:
+      AvailabilityZone: !Select
+        - 0
+        - Fn::GetAZs: !Ref 'AWS::Region'
+      ImageId: !FindInMap ["RegionMap", !Ref "AWS::Region", "AMI"]
+      InstanceType: !Ref vmType
+      Monitoring: true
+      KeyName: !Ref keyPairName
+      NetworkInterfaces:
+        -
+          NetworkInterfaceId: !Ref prvInterface
+          DeviceIndex: 0
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join [' ', [!Ref cloudwareDomain, 'gateway']
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+        -
+          Key: 'cloudware_machine_role'
+          Value: !Ref vmRole
+        -
+          Key: 'cloudware_machine_name'
+          Value: 'gateway'
+        -
+          Key: 'cloudware_machine_flavour'
+          Value: !Ref vmFlavour
+        -
+          Key: 'cloudware_prv_subnet_ip'
+          Value: 10.78.100.10
+
+  publicIp:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+
+  publicIpAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      NetworkInterfaceId: !Ref prvInterface
+      AllocationId: !GetAtt publicIp.AllocationId

--- a/providers/aws/templates/machine-login.yml
+++ b/providers/aws/templates/machine-login.yml
@@ -52,6 +52,7 @@ Resources:
       GroupDescription: 'Flight Connector Login'
       VpcId: !Ref networkId
       SecurityGroupIngress:
+        -
           IpProtocol: 'tcp'
           FromPort: 22
           ToPort: 22

--- a/providers/aws/templates/machine-login.yml
+++ b/providers/aws/templates/machine-login.yml
@@ -1,0 +1,156 @@
+---
+Description: 'FlightConnector Login Node Template'
+Parameters:
+  cloudwareId:
+    Type: String
+    Description: 'Enter the Cloudware UUID'
+
+  cloudwareDomain:
+    Type: String
+    Description: 'Enter the Cloudware domain name'
+
+  networkId:
+    Type: String
+    Description: 'Enter the VPC/network ID'
+
+  prvSubnetId:
+    Type: String
+    Description: 'Enter the prv subnet ID'
+
+  prvSubnetCidr:
+    Type: String
+    Description: 'Enter the prv subnet CIDR'
+
+  keyPairName:
+    Default: 'aws_ireland'
+    Type: String
+    Description: 'Select the AWS keypair to assign to the instance'
+
+  vmType:
+    Type: String
+    Description: 'Enter the size of the instance'
+
+  vmRole:
+    Type: String
+    Description: 'Enter the Cloudware instance type'
+
+  vmFlavour:
+    Type: String
+    Description: 'Enter the VM flavour'
+
+Mappings:
+  RegionMap:
+    eu-west-1:
+      "AMI": "ami-d266dfab"
+
+Resources:
+  securityGroupLogin:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: RouteInternetLogin
+    Properties:
+      GroupName: !Join ['-', [!Ref cloudwareDomain, 'login']]
+      GroupDescription: 'Flight Connector Login'
+      VpcId: !Ref networkId
+      SecurityGroupIngress:
+          IpProtocol: 'tcp'
+          FromPort: 22
+          ToPort: 22
+          CidrIp: '0.0.0.0/0'
+          Description: 'Allow inbound SSH access'
+        -
+          IpProtocol: 'icmp'
+          FromPort: '8'
+          ToPort: '-1'
+          CidrIp: '0.0.0.0/0'
+          Description: 'Allow ping'
+        -
+          IpProtocol: 'tcp'
+          FromPort: 2005
+          ToPort: 2005
+          CidrIp: '0.0.0.0/0'
+          Description: 'Allow inbound cluster VPN access'
+      SecurityGroupEgress:
+        -
+          IpProtocol: '-1'
+          FromPort: 0
+          ToPort: 65535
+          CidrIp: '0.0.0.0/0'
+          Description: 'Allow outbound internet access'
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', [!Ref cloudwareDomain, 'login']]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+
+  prvInterface:
+    Type: AWS::EC2::NetworkInterface
+    Properties:
+      Description: !Join [' ', [!Ref cloudwareDomain, 'login', 'prv network interface']]
+      SourceDestCheck: false
+      GroupSet:
+        - !Ref securityGroupLogin
+      PrivateIpAddress: 10.100.2.10
+      SubnetId: !Ref prvSubnetId
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join ['-', [!Ref cloudwareDomain, 'login', 'prv']]
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+
+  master:
+    Type: AWS::EC2::Instance
+    Properties:
+      AvailabilityZone: !Select
+        - 0
+        - Fn::GetAZs: !Ref 'AWS::Region'
+      ImageId: !FindInMap ["RegionMap", !Ref "AWS::Region", "AMI"]
+      InstanceType: !Ref vmType
+      Monitoring: true
+      KeyName: !Ref keyPairName
+      NetworkInterfaces:
+        -
+          NetworkInterfaceId: !Ref prvInterface
+          DeviceIndex: 0
+      Tags:
+        -
+          Key: 'Name'
+          Value: !Join [' ', [!Ref cloudwareDomain, 'login']
+        -
+          Key: 'cloudware_id'
+          Value: !Ref cloudwareId
+        -
+          Key: 'cloudware_domain'
+          Value: !Ref cloudwareDomain
+        -
+          Key: 'cloudware_machine_role'
+          Value: !Ref vmRole
+        -
+          Key: 'cloudware_machine_name'
+          Value: 'login'
+        -
+          Key: 'cloudware_machine_flavour'
+          Value: !Ref vmFlavour
+        -
+          Key: 'cloudware_prv_subnet_ip'
+          Value: 10.100.2.10
+
+  publicIp:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+
+  publicIpAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      NetworkInterfaceId: !Ref prvInterface
+      AllocationId: !GetAtt publicIp.AllocationId

--- a/providers/aws/templates/machine-login.yml
+++ b/providers/aws/templates/machine-login.yml
@@ -34,6 +34,13 @@ Parameters:
     Type: String
     Description: 'Enter the VM flavour'
 
+  clusterIndex: 
+    Type: Number
+    Description: 'Enter the cluster index'
+    Default: 1
+    MinValue: 1
+    MaxValue: 99
+
 Mappings:
   RegionMap:
     eu-west-1:
@@ -90,7 +97,7 @@ Resources:
       SourceDestCheck: false
       GroupSet:
         - !Ref securityGroupLogin
-      PrivateIpAddress: 10.100.2.10
+      PrivateIpAddress: !Join ['', ['10.100.', !Ref clusterIndex, '10']]
       SubnetId: !Ref prvSubnetId
       Tags:
         -
@@ -138,7 +145,7 @@ Resources:
           Value: !Ref vmFlavour
         -
           Key: 'cloudware_prv_subnet_ip'
-          Value: 10.100.2.10
+          Value: !Join ['', ['10.100.', !Ref clusterIndex, '10']]
 
   publicIp:
     Type: AWS::EC2::EIP

--- a/providers/aws/templates/machine-login.yml
+++ b/providers/aws/templates/machine-login.yml
@@ -97,7 +97,7 @@ Resources:
       SourceDestCheck: false
       GroupSet:
         - !Ref securityGroupLogin
-      PrivateIpAddress: !Join ['', ['10.100.', !Ref clusterIndex, '10']]
+      PrivateIpAddress: !Join ['', ['10.100.', !Ref clusterIndex, '.10']]
       SubnetId: !Ref prvSubnetId
       Tags:
         -
@@ -145,7 +145,7 @@ Resources:
           Value: !Ref vmFlavour
         -
           Key: 'cloudware_prv_subnet_ip'
-          Value: !Join ['', ['10.100.', !Ref clusterIndex, '10']]
+          Value: !Join ['', ['10.100.', !Ref clusterIndex, '.10']]
 
   publicIp:
     Type: AWS::EC2::EIP

--- a/providers/aws/templates/machine-login.yml
+++ b/providers/aws/templates/machine-login.yml
@@ -17,10 +17,6 @@ Parameters:
     Type: String
     Description: 'Enter the prv subnet ID'
 
-  prvSubnetCidr:
-    Type: String
-    Description: 'Enter the prv subnet CIDR'
-
   keyPairName:
     Default: 'aws_ireland'
     Type: String
@@ -46,7 +42,6 @@ Mappings:
 Resources:
   securityGroupLogin:
     Type: AWS::EC2::SecurityGroup
-    DependsOn: RouteInternetLogin
     Properties:
       GroupName: !Join ['-', [!Ref cloudwareDomain, 'login']]
       GroupDescription: 'Flight Connector Login'
@@ -125,7 +120,7 @@ Resources:
       Tags:
         -
           Key: 'Name'
-          Value: !Join [' ', [!Ref cloudwareDomain, 'login']
+          Value: !Join [' ', [!Ref cloudwareDomain, 'login']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId

--- a/support/flightconnector/domain0-gateway.sh
+++ b/support/flightconnector/domain0-gateway.sh
@@ -1,0 +1,219 @@
+yum -y install epel-release
+yum -y install openvpn easy-rsa
+cp -pav /usr/share/easy-rsa/3.0.3 /etc/openvpn/easyrsa
+cd /etc/openvpn/easyrsa
+
+cat<< 'EOF' > /etc/openvpn/easyrsa/vars
+if [ -z "$EASYRSA_CALLER" ]; then
+    echo "You appear to be sourcing an Easy-RSA 'vars' file." >&2
+    echo "This is no longer necessary and is disallowed. See the section called" >&2
+    echo "'How to use this file' near the top comments for more details." >&2
+    return 1
+fi
+set_var EASYRSA        "$PWD"
+set_var EASYRSA_OPENSSL        "openssl"
+set_var EASYRSA_PKI            "$EASYRSA/pki"
+set_var EASYRSA_DN     "org"
+set_var EASYRSA_REQ_COUNTRY    "UK"
+set_var EASYRSA_REQ_PROVINCE   "Oxfordshire"
+set_var EASYRSA_REQ_CITY       "Oxford"
+set_var EASYRSA_REQ_ORG        "Alces Flight Ltd"
+set_var EASYRSA_REQ_EMAIL      "ssl@alces-flight.com"
+set_var EASYRSA_REQ_OU         "Infrastructure"
+set_var EASYRSA_KEY_SIZE       2048
+set_var EASYRSA_ALGO           rsa
+set_var EASYRSA_CA_EXPIRE      3650
+set_var EASYRSA_CERT_EXPIRE    3650
+set_var EASYRSA_CRL_DAYS       180
+set_var EASYRSA_TEMP_FILE      "$EASYRSA_PKI/extensions.temp"
+set_var EASYRSA_BATCH 		"true"
+EOF
+
+./easyrsa init-pki
+./easyrsa --req-cn=cluster0 build-ca nopass
+
+./easyrsa --req-cn=cluster0 gen-req cluster0 nopass
+./easyrsa sign-req server cluster0
+
+./easyrsa --req-cn=clusterX gen-req clusterX nopass
+./easyrsa sign-req client clusterX
+
+./easyrsa --req-cn=cluster1 gen-req cluster1 nopass
+./easyrsa sign-req client cluster1
+
+./easyrsa --req-cn=cluster2 gen-req cluster2 nopass
+./easyrsa sign-req client cluster2
+
+./easyrsa --req-cn=cluster3 gen-req cluster3 nopass
+./easyrsa sign-req client cluster3
+
+./easyrsa --req-cn=cluster4 gen-req cluster4 nopass
+./easyrsa sign-req client cluster4
+
+./easyrsa gen-dh
+./easyrsa gen-crl
+openvpn --genkey --secret ta.key
+
+cat << EOF > /etc/openvpn/flightconnector.conf
+mode server
+tls-server
+port 2005
+proto tcp-server
+dev tun0
+ca /etc/openvpn/easyrsa/pki/ca.crt
+cert /etc/openvpn/easyrsa/pki/issued/cluster0.crt
+key /etc/openvpn/easyrsa/pki/private/cluster0.key
+dh /etc/openvpn/easyrsa/pki/dh.pem
+crl-verify /etc/openvpn/easyrsa/pki/crl.pem
+client-config-dir ccd-clusters
+ccd-exclusive
+client-to-client
+ifconfig 10.78.110.1 255.255.255.0
+topology subnet
+route 10.10.0.0 255.255.0.0 10.78.110.2
+route 10.100.1.0 255.255.255.0 10.78.110.11
+route 10.100.2.0 255.255.255.0 10.78.110.12
+route 10.100.3.0 255.255.255.0 10.78.110.13
+route 10.100.4.0 255.255.255.0 10.78.110.14
+keepalive 10 120
+comp-lzo adaptive
+tls-auth /etc/openvpn/easyrsa/ta.key 0
+cipher AES-256-CBC
+auth SHA512
+tls-version-min 1.2
+tls-cipher TLS-DHE-RSA-WITH-AES-256-GCM-SHA384
+persist-key
+persist-tun
+status openvpn-status.log
+log         /var/log/openvpn.log
+log-append  /var/log/openvpn.log
+verb 3
+EOF
+
+mkdir /etc/openvpn/ccd-clusters
+cat << EOF > /etc/openvpn/ccd-clusters/clusterX
+ifconfig-push 10.78.110.2 255.255.255.0
+push "route 10.78.100.0 255.255.255.0 10.78.110.1"
+push "route 10.100.1.0 255.255.255.0 10.78.110.11"
+push "route 10.100.2.0 255.255.255.0 10.78.110.12"
+push "route 10.100.3.0 255.255.255.0 10.78.110.13"
+push "route 10.100.4.0 255.255.255.0 10.78.110.14"
+iroute 10.10.0.0 255.255.0.0
+EOF
+
+cat << EOF > /etc/openvpn/ccd-clusters/cluster1
+ifconfig-push 10.78.110.11 255.255.255.0
+push "route 10.78.100.0 255.255.255.0 10.78.110.1"
+push "route 10.10.0.0 255.255.0.0 10.78.110.2"
+push "route 10.100.2.0 255.255.255.0 10.78.110.12"
+push "route 10.100.3.0 255.255.255.0 10.78.110.13"
+push "route 10.100.4.0 255.255.255.0 10.78.110.14"
+iroute 10.100.1.0 255.255.0.0
+EOF
+
+cat << EOF > /etc/openvpn/ccd-clusters/cluster2
+ifconfig-push 10.78.110.12 255.255.255.0
+push "route 10.78.100.0 255.255.255.0 10.78.110.1"
+push "route 10.10.0.0 255.255.0.0 10.78.110.2"
+push "route 10.100.1.0 255.255.255.0 10.78.110.11"
+push "route 10.100.3.0 255.255.255.0 10.78.110.13"
+push "route 10.100.4.0 255.255.255.0 10.78.110.14"
+iroute 10.100.2.0 255.255.0.0
+EOF
+
+cat << EOF > /etc/openvpn/ccd-clusters/cluster3
+ifconfig-push 10.78.110.13 255.255.255.0
+push "route 10.78.100.0 255.255.255.0 10.78.110.1"
+push "route 10.10.0.0 255.255.0.0 10.78.110.2"
+push "route 10.100.1.0 255.255.255.0 10.78.110.11"
+push "route 10.100.2.0 255.255.255.0 10.78.110.12"
+push "route 10.100.4.0 255.255.255.0 10.78.110.13"
+iroute 10.100.3.0 255.255.0.0
+EOF
+
+cat << EOF > /etc/openvpn/ccd-clusters/cluster4
+ifconfig-push 10.78.110.14 255.255.255.0
+push "route 10.78.100.0 255.255.255.0 10.78.110.1"
+push "route 10.10.0.0 255.255.0.0 10.78.110.2"
+push "route 10.100.1.0 255.255.255.0 10.78.110.11"
+push "route 10.100.2.0 255.255.255.0 10.78.110.12"
+push "route 10.100.3.0 255.255.255.0 10.78.110.13"
+iroute 10.100.4.0 255.255.0.0
+EOF
+
+
+cat << '_EOF_' >> /etc/openvpn/buildinstaller.sh
+CLUSTER=$1
+IP=`curl --silent http://ipecho.net/plain`
+CA=`cat /etc/openvpn/easyrsa/pki/ca.crt`
+CRT=`cat /etc/openvpn/easyrsa/pki/issued/$CLUSTER.crt`
+KEY=`cat /etc/openvpn/easyrsa/pki/private/$CLUSTER.key`
+TA=`cat /etc/openvpn/easyrsa/ta.key`
+cat << EOF > /root/install_$CLUSTER.run
+cat << EOD > /etc/openvpn/flightconnector.conf
+client
+dev tun
+proto tcp
+remote $IP 2005
+remote-cert-tls server
+resolv-retry infinite
+nobind
+persist-key
+persist-tun
+<ca>
+$CA
+</ca>
+<cert>
+$CRT
+</cert>
+<key>
+$KEY
+</key>
+comp-lzo adaptive
+verb 0
+cipher AES-256-CBC
+auth SHA512
+tls-version-min 1.2
+tls-client
+tls-cipher TLS-DHE-RSA-WITH-AES-256-GCM-SHA384
+key-direction 1
+<tls-auth>
+$TA
+</tls-auth>
+topology subnet
+EOD
+EOF
+_EOF_
+
+bash /etc/openvpn/buildinstaller.sh clusterX
+bash /etc/openvpn/buildinstaller.sh cluster1
+bash /etc/openvpn/buildinstaller.sh cluster2
+bash /etc/openvpn/buildinstaller.sh cluster3
+bash /etc/openvpn/buildinstaller.sh cluster4
+
+
+systemctl enable openvpn@flightconnector
+
+
+systemctl disable iptables
+systemctl enable firewalld
+systemctl stop iptables
+systemctl start firewalld
+systemctl disable cloud-init
+systemctl disable cloud-init-local
+systemctl disable cloud-config
+systemctl disable cloud-final
+
+firewall-cmd --new-zone cluster0 --permanent
+firewall-cmd --add-interface tun0 --zone cluster0 --permanent
+firewall-cmd --remove-interface eth0 --zone public
+firewall-cmd --remove-interface eth0 --zone public --permanent
+firewall-cmd --add-interface eth0 --zone external --permanent
+firewall-cmd --add-interface eth0 --zone external
+firewall-cmd --add-port 2005/tcp --zone external --permanent
+
+firewall-cmd --add-target=ACCEPT --zone cluster0 --permanent
+
+sed '/^ZONE=/{h;s/=.*/=external/};${x;/^$/{s//ZONE=external/;H};x}' /etc/sysconfig/network-scripts/ifcfg-eth0 -i
+
+echo "Please reboot"

--- a/support/flightconnector/domain0-gateway.sh
+++ b/support/flightconnector/domain0-gateway.sh
@@ -184,6 +184,8 @@ $TA
 </tls-auth>
 topology subnet
 EOD
+systemctl enable openvpn@flightconnector
+systemctl start openvpn@flightconnector
 EOF
 _EOF_
 

--- a/support/flightconnector/domain0-gateway.sh
+++ b/support/flightconnector/domain0-gateway.sh
@@ -150,6 +150,8 @@ CRT=`cat /etc/openvpn/easyrsa/pki/issued/$CLUSTER.crt`
 KEY=`cat /etc/openvpn/easyrsa/pki/private/$CLUSTER.key`
 TA=`cat /etc/openvpn/easyrsa/ta.key`
 cat << EOF > /root/install_$CLUSTER.run
+yum install -y epel-release
+yum install -y openvpn
 cat << EOD > /etc/openvpn/flightconnector.conf
 client
 dev tun

--- a/support/flightconnector/domain0-gateway.sh
+++ b/support/flightconnector/domain0-gateway.sh
@@ -212,7 +212,7 @@ firewall-cmd --add-interface eth0 --zone external --permanent
 firewall-cmd --add-interface eth0 --zone external
 firewall-cmd --add-port 2005/tcp --zone external --permanent
 
-firewall-cmd --add-target=ACCEPT --zone cluster0 --permanent
+firewall-cmd --set-target=ACCEPT --zone cluster0 --permanent
 
 sed '/^ZONE=/{h;s/=.*/=external/};${x;/^$/{s//ZONE=external/;H};x}' /etc/sysconfig/network-scripts/ifcfg-eth0 -i
 


### PR DESCRIPTION
This PR address #27 and #28.

The templates do not reference the management network so it is best to get #30 completed before testing and merging this branch. 

There'll most likely be issues caused as a result of cherry picking input parameters (instead of using all the ones cloudware would expect) - prepare for an influx of issues!