### PR TITLE
Clean up the use of the `Whirly`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,6 +47,7 @@ Metrics/ClassLength:
     - 'lib/cloudware/domain.rb'
     - 'lib/cloudware/aws.rb'
     - 'lib/cloudware/commands/**/*.rb'
+    - 'lib/cloudware/cli.rb'
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -28,5 +28,11 @@ module Cloudware
       Cloudware.log.fatal(e.message)
       raise e
     end
+
+    def run_whirly(status)
+      Whirly.start status: status do
+        yield if block_given?
+      end
+    end
   end
 end

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -30,8 +30,10 @@ module Cloudware
     end
 
     def run_whirly(status)
-      Whirly.start status: status do
-        yield if block_given?
+      update_status = proc { |s| Whirly.status = s.bold }
+      Whirly.start do
+        update_status.call(status)
+        yield update_status if block_given?
       end
     end
   end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -24,7 +24,7 @@ module Cloudware
           options.mgtsubnetcidr = ask('Mgt subnet CIDR: ') if options.mgtsubnetcidr.nil?
           d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
 
-          Whirly.start status: 'Verifying network CIDR is valid' do
+          run_whirly('Verifying network CIDR is valid') do
             raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
             Whirly.status = 'Verifying prv subnet CIDR is valid'
             raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
@@ -32,18 +32,18 @@ module Cloudware
             raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           end
 
-          Whirly.start status: 'Checking domain name is valid' do
+          run_whirly('Checking domain name is valid') do
             raise("Domain name #{options.name} is not valid") unless d.valid_name?
           end
 
-          Whirly.start status: 'Checking domain does not already exist' do
+          run_whirly('Checking domain does not already exist') do
             raise("Domain name #{options.name} already exists") if d.exists?
             d.provider = options.provider.to_s
             Whirly.status = 'Verifying provider is valid'
             raise("Provider #{options.provider} does not exist") unless d.valid_provider?
           end
 
-          Whirly.start status: 'Creating new deployment' do
+          run_whirly('Creating new deployment') do
             d.create
           end
         end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -24,28 +24,28 @@ module Cloudware
           options.mgtsubnetcidr = ask('Mgt subnet CIDR: ') if options.mgtsubnetcidr.nil?
           d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
 
-          Whirly.start status: 'Verifying network CIDR is valid'
-          raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
-          Whirly.status = 'Verifying prv subnet CIDR is valid'
-          raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
-          Whirly.status = 'Verifying mgt subnet CIDR is valid'
-          raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
-          Whirly.stop
+          Whirly.start status: 'Verifying network CIDR is valid' do
+            raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
+            Whirly.status = 'Verifying prv subnet CIDR is valid'
+            raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
+            Whirly.status = 'Verifying mgt subnet CIDR is valid'
+            raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
+          end
 
-          Whirly.start status: 'Checking domain name is valid'
-          raise("Domain name #{options.name} is not valid") unless d.valid_name?
-          Whirly.stop
+          Whirly.start status: 'Checking domain name is valid' do
+            raise("Domain name #{options.name} is not valid") unless d.valid_name?
+          end
 
-          Whirly.start status: 'Checking domain does not already exist'
-          raise("Domain name #{options.name} already exists") if d.exists?
-          d.provider = options.provider.to_s
-          Whirly.status = 'Verifying provider is valid'
-          raise("Provider #{options.provider} does not exist") unless d.valid_provider?
-          Whirly.stop
+          Whirly.start status: 'Checking domain does not already exist' do
+            raise("Domain name #{options.name} already exists") if d.exists?
+            d.provider = options.provider.to_s
+            Whirly.status = 'Verifying provider is valid'
+            raise("Provider #{options.provider} does not exist") unless d.valid_provider?
+          end
 
-          Whirly.start status: 'Creating new deployment'
-          d.create
-          Whirly.stop
+          Whirly.start status: 'Creating new deployment' do
+            d.create
+          end
         end
       end
     end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -24,26 +24,26 @@ module Cloudware
           options.mgtsubnetcidr = ask('Mgt subnet CIDR: ') if options.mgtsubnetcidr.nil?
           d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
 
-          run_whirly('Verifying network CIDR is valid') do
+          run_whirly('Verifying network CIDR is valid') do |update_status|
             raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
-            Whirly.status = 'Verifying prv subnet CIDR is valid'
+            update_status.call('Verifying prv subnet CIDR is valid')
             raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
-            Whirly.status = 'Verifying mgt subnet CIDR is valid'
+            update_status.call('Verifying mgt subnet CIDR is valid')
             raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           end
 
-          run_whirly('Checking domain name is valid') do
+          run_whirly('Checking domain name is valid') do |update_status|
             raise("Domain name #{options.name} is not valid") unless d.valid_name?
           end
 
-          run_whirly('Checking domain does not already exist') do
+          run_whirly('Checking domain does not already exist') do |update_status|
             raise("Domain name #{options.name} already exists") if d.exists?
             d.provider = options.provider.to_s
-            Whirly.status = 'Verifying provider is valid'
+            update_status.call('Verifying provider is valid')
             raise("Provider #{options.provider} does not exist") unless d.valid_provider?
           end
 
-          run_whirly('Creating new deployment') do
+          run_whirly('Creating new deployment') do |update_status|
             d.create
           end
         end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -32,7 +32,7 @@ module Cloudware
             raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           end
 
-          run_whirly('Checking domain name is valid') do |update_status|
+          run_whirly('Checking domain name is valid') do
             raise("Domain name #{options.name} is not valid") unless d.valid_name?
           end
 
@@ -43,7 +43,7 @@ module Cloudware
             raise("Provider #{options.provider} does not exist") unless d.valid_provider?
           end
 
-          run_whirly('Creating new deployment') do |update_status|
+          run_whirly('Creating new deployment') do
             d.create
           end
         end

--- a/lib/cloudware/commands/domain/destroy.rb
+++ b/lib/cloudware/commands/domain/destroy.rb
@@ -10,11 +10,11 @@ module Cloudware
           options.name = ask('Domain name: ') if options.name.nil?
           d.name = options.name.to_s
 
-          Whirly.start status: 'Checking domain exists' do
+          run_whirly('Checking domain exists') do
             raise("Domain name #{options.name} does not exist") unless d.exists?
           end
 
-          Whirly.start status: "Destroying domain #{options.name}" do
+          run_whirly("Destroying domain #{options.name}") do
             d.destroy
           end
         end

--- a/lib/cloudware/commands/domain/destroy.rb
+++ b/lib/cloudware/commands/domain/destroy.rb
@@ -10,13 +10,13 @@ module Cloudware
           options.name = ask('Domain name: ') if options.name.nil?
           d.name = options.name.to_s
 
-          Whirly.start status: 'Checking domain exists'
-          raise("Domain name #{options.name} does not exist") unless d.exists?
-          Whirly.stop
+          Whirly.start status: 'Checking domain exists' do
+            raise("Domain name #{options.name} does not exist") unless d.exists?
+          end
 
-          Whirly.start status: "Destroying domain #{options.name}"
-          d.destroy
-          Whirly.stop
+          Whirly.start status: "Destroying domain #{options.name}" do
+            d.destroy
+          end
         end
       end
     end

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -16,9 +16,9 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available domains'
-          raise('No available domains') if d.list.nil?
-          Whirly.stop
+          Whirly.start status: 'Fetching available domains' do
+            raise('No available domains') if d.list.nil?
+          end
           d.list.each do |k, v|
             r << [k, v[:network_cidr], v[:prv_subnet_cidr], v[:mgt_subnet_cidr], v[:provider], v[:region]]
           end

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -16,7 +16,7 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available domains' do
+          run_whirly('Fetching available domains') do
             raise('No available domains') if d.list.nil?
           end
           d.list.each do |k, v|

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,11 +29,11 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          Whirly.start status: 'Verifying domain exists' do
+          run_whirly('Verifying domain exists') do
             raise("Domain #{options.domain} does not exist") unless m.valid_domain?
           end
 
-          Whirly.start status: 'Checking machine name is valid' do
+          run_whirly('Checking machine name is valid') do
             raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
             Whirly.status = 'Verifying prv IP address'
             raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
@@ -41,7 +41,7 @@ module Cloudware
             raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
           end
 
-          Whirly.start status: 'Creating new deployment' do
+          run_whirly('Creating new deployment') do
             m.create
           end
         end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,19 +29,19 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          run_whirly('Verifying domain exists') do
+          run_whirly('Verifying domain exists') do |update_status|
             raise("Domain #{options.domain} does not exist") unless m.valid_domain?
           end
 
-          run_whirly('Checking machine name is valid') do
+          run_whirly('Checking machine name is valid') do |update_status|
             raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
-            Whirly.status = 'Verifying prv IP address'
+            update_status.call('Verifying prv IP address')
             raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
-            Whirly.status = 'Verifying mgt IP address'
+            update_status.call('Verifying mgt IP address')
             raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
           end
 
-          run_whirly('Creating new deployment') do
+          run_whirly('Creating new deployment') do |update_status|
             m.create
           end
         end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,7 +29,7 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          run_whirly('Verifying domain exists') do |update_status|
+          run_whirly('Verifying domain exists') do
             raise("Domain #{options.domain} does not exist") unless m.valid_domain?
           end
 
@@ -41,7 +41,7 @@ module Cloudware
             raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
           end
 
-          run_whirly('Creating new deployment') do |update_status|
+          run_whirly('Creating new deployment') do
             m.create
           end
         end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,21 +29,21 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          Whirly.start status: 'Verifying domain exists'
-          raise("Domain #{options.domain} does not exist") unless m.valid_domain?
-          Whirly.stop
+          Whirly.start status: 'Verifying domain exists' do
+            raise("Domain #{options.domain} does not exist") unless m.valid_domain?
+          end
 
-          Whirly.start status: 'Checking machine name is valid'
-          raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
-          Whirly.status = 'Verifying prv IP address'
-          raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
-          Whirly.status = 'Verifying mgt IP address'
-          raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
-          Whirly.stop
+          Whirly.start status: 'Checking machine name is valid' do
+            raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
+            Whirly.status = 'Verifying prv IP address'
+            raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
+            Whirly.status = 'Verifying mgt IP address'
+            raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
+          end
 
-          Whirly.start status: 'Creating new deployment'
-          m.create
-          Whirly.stop
+          Whirly.start status: 'Creating new deployment' do
+            m.create
+          end
         end
       end
     end

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -13,13 +13,13 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           m.domain = options.domain.to_s
 
-          Whirly.start status: 'Checking machine exists'
-          raise('Machine does not exist') unless m.exists?
-          Whirly.stop
+          Whirly.start status: 'Checking machine exists' do
+            raise('Machine does not exist') unless m.exists?
+          end
 
-          Whirly.start status: "Destroying #{options.name} in domain #{options.domain}"
-          m.destroy
-          Whirly.stop
+          Whirly.start status: "Destroying #{options.name} in domain #{options.domain}" do
+            m.destroy
+          end
         end
       end
     end

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -13,11 +13,11 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           m.domain = options.domain.to_s
 
-          Whirly.start status: 'Checking machine exists' do
+          run_whirly('Checking machine exists') do
             raise('Machine does not exist') unless m.exists?
           end
 
-          Whirly.start status: "Destroying #{options.name} in domain #{options.domain}" do
+          run_whirly("Destroying #{options.name} in domain #{options.domain}") do
             m.destroy
           end
         end

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -15,18 +15,18 @@ module Cloudware
           case options.output.to_s
           when 'table'
             table = Terminal::Table.new do |t|
-              Whirly.start status: 'Fetching machine info'
-              t.add_row ['Machine name'.bold, m.name]
-              t.add_row ['Domain name'.bold, m.get_item('domain')]
-              t.add_row ['Machine role'.bold, m.get_item('role')]
-              t.add_row ['Prv subnet IP'.bold, m.get_item('prv_ip')]
-              t.add_row ['Mgt subnet IP'.bold, m.get_item('mgt_ip')]
-              t.add_row ['External IP'.bold, m.get_item('ext_ip')]
-              t.add_row ['Machine state'.bold, m.get_item('state')]
-              t.add_row ['Machine type'.bold, m.get_item('type')]
-              t.add_row ['Machine flavour'.bold, m.get_item('flavour')]
-              t.add_row ['Provider'.bold, m.get_item('provider')]
-              Whirly.stop
+              Whirly.start status: 'Fetching machine info' do
+                t.add_row ['Machine name'.bold, m.name]
+                t.add_row ['Domain name'.bold, m.get_item('domain')]
+                t.add_row ['Machine role'.bold, m.get_item('role')]
+                t.add_row ['Prv subnet IP'.bold, m.get_item('prv_ip')]
+                t.add_row ['Mgt subnet IP'.bold, m.get_item('mgt_ip')]
+                t.add_row ['External IP'.bold, m.get_item('ext_ip')]
+                t.add_row ['Machine state'.bold, m.get_item('state')]
+                t.add_row ['Machine type'.bold, m.get_item('type')]
+                t.add_row ['Machine flavour'.bold, m.get_item('flavour')]
+                t.add_row ['Provider'.bold, m.get_item('provider')]
+              end
               t.style = { all_separators: true }
             end
             puts table

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -15,7 +15,7 @@ module Cloudware
           case options.output.to_s
           when 'table'
             table = Terminal::Table.new do |t|
-              Whirly.start status: 'Fetching machine info' do
+              run_whirly('Fetching machine info') do
                 t.add_row ['Machine name'.bold, m.name]
                 t.add_row ['Domain name'.bold, m.get_item('domain')]
                 t.add_row ['Machine role'.bold, m.get_item('role')]

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -14,7 +14,7 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available machines' do
+          run_whirly('Fetching available machines') do
             raise('No available machines') if m.list.nil?
           end
           m.list.each do |_k, v|

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -14,9 +14,9 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available machines'
-          raise('No available machines') if m.list.nil?
-          Whirly.stop
+          Whirly.start status: 'Fetching available machines' do
+            raise('No available machines') if m.list.nil?
+          end
           m.list.each do |_k, v|
             r << [v[:name], v[:domain], v[:role], v[:prv_ip], v[:mgt_ip], v[:type], v[:state]]
           end

--- a/lib/cloudware/commands/machine/power/off.rb
+++ b/lib/cloudware/commands/machine/power/off.rb
@@ -13,9 +13,9 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering off machine #{options.name}"
-            machine.power_off
-            Whirly.stop
+            Whirly.start status: "Powering off machine #{options.name}" do
+              machine.power_off
+            end
           end
         end
       end

--- a/lib/cloudware/commands/machine/power/off.rb
+++ b/lib/cloudware/commands/machine/power/off.rb
@@ -13,7 +13,7 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering off machine #{options.name}" do
+            run_whirly("Powering off machine #{options.name}") do
               machine.power_off
             end
           end

--- a/lib/cloudware/commands/machine/power/on.rb
+++ b/lib/cloudware/commands/machine/power/on.rb
@@ -13,7 +13,7 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering on machine #{options.name}" do
+            run_whirly("Powering on machine #{options.name}") do
               machine.power_on
             end
           end

--- a/lib/cloudware/commands/machine/power/on.rb
+++ b/lib/cloudware/commands/machine/power/on.rb
@@ -13,9 +13,9 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering on machine #{options.name}"
-            machine.power_on
-            Whirly.stop
+            Whirly.start status: "Powering on machine #{options.name}" do
+              machine.power_on
+            end
           end
         end
       end

--- a/lib/cloudware/commands/machine/rebuild.rb
+++ b/lib/cloudware/commands/machine/rebuild.rb
@@ -12,7 +12,7 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           machine.domain = options.domain.to_s
 
-          Whirly.start status: "Recreating machine #{options.name}" do
+          run_whirly("Recreating machine #{options.name}") do
             machine.rebuild
           end
         end

--- a/lib/cloudware/commands/machine/rebuild.rb
+++ b/lib/cloudware/commands/machine/rebuild.rb
@@ -12,9 +12,9 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           machine.domain = options.domain.to_s
 
-          Whirly.start status: "Recreating machine #{options.name}"
-          machine.rebuild
-          Whirly.stop
+          Whirly.start status: "Recreating machine #{options.name}" do
+            machine.rebuild
+          end
         end
       end
     end


### PR DESCRIPTION
Various changes to how the `Whirly` is used. The short version is the `Whirly` has been abstracted away to the `Command` object. This means all the other commands can now use the `Whirly` in a consistent manner by just passing it a string.

The whirly `status` is now always **bold** (again).