### PR TITLE
Integrate ActiveModel as a replacement for the Domain class

### DIFF
--- a/.flightconnector.yml.example
+++ b/.flightconnector.yml.example
@@ -2,9 +2,8 @@
 # The file then needs to be stored in your home directory as:
 # ~/.flightconnector.yml
 
-# Location to store Cloudware logs
 general:
-  log_file: '/var/log/cloudware.log'
+  log_file: '/var/log/flightconnector.log'
 
 # Provider credentials
 provider:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,6 +47,7 @@ Metrics/ClassLength:
     - 'lib/cloudware/domain.rb'
     - 'lib/cloudware/aws.rb'
     - 'lib/cloudware/commands/**/*.rb'
+    - 'lib/cloudware/cli.rb'
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ rvm:
 sudo: required
 install:
   - cp ./.flightconnector.yml.example ~/.flightconnector.yml
+  - sed -i 's#/var/log#/tmp#g' ~/.flightconnector.yml
+  - touch /tmp/flightconnector.log
   - bundle install
 script: rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ rvm:
  - 2.4.1
 sudo: required
 install:
+  - cp ./.flightconnector.yml.example ~/.flightconnector.yml
   - bundle install
 script: rspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'activemodel'
 gem 'activesupport'
 gem 'aws-sdk-cloudformation'
 gem 'aws-sdk-ec2'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'activesupport'
 gem 'aws-sdk-cloudformation'
 gem 'aws-sdk-ec2'
 gem 'azure_mgmt_compute'

--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,6 @@ gem 'whirly'
 group :development do
   gem 'rubocop', '~> 0.52.1', require: false
   gem 'rubocop-rspec'
+  gem 'rspec'
+  gem 'factory_bot'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (5.2.0)
+      activesupport (= 5.2.0)
     activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -159,6 +161,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activemodel
   activesupport
   aws-sdk-cloudformation
   aws-sdk-ec2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/alces-software/commander
-  revision: cd637ecd5c590b18daa9f044fd5c771c34699245
+  revision: 4090e181cf280f228543e35ad21af219a6d2f626
   specs:
-    commander (4.4.4.pre.alces0)
+    commander (4.4.4.pre.alces2)
       highline (~> 1.7.2)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
+    factory_bot (4.8.2)
+      activesupport (>= 3.0.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -170,6 +172,7 @@ DEPENDENCIES
   azure_mgmt_resources
   colorize
   commander!
+  factory_bot
   google-cloud-resource_manager
   ipaddr
   require_all

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,11 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
@@ -68,6 +73,8 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
     ipaddr (1.2.0)
     jmespath (1.3.1)
     jwt (1.5.6)
@@ -79,6 +86,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    minitest (5.11.3)
     ms_rest (0.7.2)
       concurrent-ruby (~> 1.0)
       faraday (~> 0.9)
@@ -135,7 +143,10 @@ GEM
       multi_json (~> 1.10)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thread_safe (0.3.6)
     timeliness (0.3.8)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
@@ -148,6 +159,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   aws-sdk-cloudformation
   aws-sdk-ec2
   azure_mgmt_compute

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $ cloudware domain create \
   --provider aws \
   --region eu-west-1 \
   --networkcidr 10.100.0.0/16 \
-  --prvsubnetcidr 10.100.1.0/24 \
+  --prisubnetcidr 10.100.1.0/24 \
   --mgtsubnetcidr 10.100.2.0/24
 Starting deployment. This may take a while..
 Deployment complete
@@ -149,7 +149,7 @@ $ cloudware machine create \
   --name master1 \
   --domain moose \
   --role master \
-  --prvip 10.100.1.11 \
+  --priip 10.100.1.11 \
   --mgtip 10.100.2.11 \
   --flavour compute \
   --type tiny

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Starting deployment. This may take a while..
 Deployment complete
 $ cloudware domain list
 +--------------------+----------------+-----------------+-----------------+----------+-----------+
-| Domain name        | Network CIDR   | Prv Subnet CIDR | Mgt Subnet CIDR | Provider | Region    |
+| Domain name        | Network CIDR   | Pri Subnet CIDR | Mgt Subnet CIDR | Provider | Region    |
 +--------------------+----------------+-----------------+-----------------+----------+-----------+
 | ancient-aardvark   | 10.0.0.0/16    | 10.0.1.0/24     | 10.0.2.0/24     | azure    | uksouth   |
 | broad-buffalo      | 10.0.0.0/16    | 10.0.1.0/24     | 10.0.2.0/24     | azure    | uksouth   |
@@ -157,7 +157,7 @@ $ cloudware machine create \
 ==> Deployment succeeded
 $ cloudware machine list
 +-------------+----------------+--------+----------------+----------------+--------------+---------+
-| Name        | Domain         | Role   | Prv IP address | Mgt IP address | Type         | State   |
+| Name        | Domain         | Role   | Pri IP address | Mgt IP address | Type         | State   |
 +-------------+----------------+--------+----------------+----------------+--------------+---------+
 | master1     | crafty-caribou | master | 10.10.1.11     | 10.10.2.11     | Standard_F4s | running |
 +-------------+----------------+--------+----------------+----------------+--------------+---------+

--- a/bin/cloud
+++ b/bin/cloud
@@ -22,13 +22,6 @@
 # For more information on the Alces Cloudware, please visit:
 # https://github.com/alces-software/cloudware
 #==============================================================================
-base_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-ENV['BUNDLE_GEMFILE'] ||= File.join(base_dir, 'Gemfile')
-
-require 'rubygems'
-require 'bundler'
-Bundler.setup(:default)
-
-require_relative File.join(base_dir, 'lib', 'cloudware')
+require_relative File.join(__FILE__, '../../../lib/cloudware')
 
 Cloudware::CLI.run! if $PROGRAM_NAME == __FILE__

--- a/lib/cloudware.rb
+++ b/lib/cloudware.rb
@@ -36,7 +36,7 @@ require 'active_support/core_ext/array'
 require 'active_model'
 require 'active_model/errors'
 
-require 'cli'
+require 'colorize'
 require 'domain'
 require 'machine'
 require 'azure'
@@ -60,3 +60,5 @@ module Cloudware
     end
   end
 end
+
+require 'cli'

--- a/lib/cloudware.rb
+++ b/lib/cloudware.rb
@@ -34,6 +34,7 @@ Bundler.setup(:default)
 require 'active_support/core_ext/string'
 require 'active_support/core_ext/array'
 require 'active_model'
+require 'active_model/errors'
 
 require 'cli'
 require 'domain'

--- a/lib/cloudware.rb
+++ b/lib/cloudware.rb
@@ -22,7 +22,13 @@
 # https://github.com/alces-software/cloudware
 #==============================================================================
 
-$LOAD_PATH << File.join(File.dirname(__FILE__), 'cloudware')
+lib_dir = File.dirname(__FILE__)
+$LOAD_PATH << File.join(lib_dir, 'cloudware')
+ENV['BUNDLE_GEMFILE'] ||= File.join(lib_dir, '..', 'Gemfile')
+
+require 'rubygems'
+require 'bundler'
+Bundler.setup(:default)
 
 require 'cli'
 require 'domain'

--- a/lib/cloudware.rb
+++ b/lib/cloudware.rb
@@ -30,6 +30,9 @@ require 'rubygems'
 require 'bundler'
 Bundler.setup(:default)
 
+# ActiveSupport modules
+require 'active_support/core_ext/string'
+
 require 'cli'
 require 'domain'
 require 'machine'

--- a/lib/cloudware.rb
+++ b/lib/cloudware.rb
@@ -32,6 +32,7 @@ Bundler.setup(:default)
 
 # ActiveSupport modules
 require 'active_support/core_ext/string'
+require 'active_support/core_ext/array'
 
 require 'cli'
 require 'domain'

--- a/lib/cloudware.rb
+++ b/lib/cloudware.rb
@@ -33,6 +33,7 @@ Bundler.setup(:default)
 # ActiveSupport modules
 require 'active_support/core_ext/string'
 require 'active_support/core_ext/array'
+require 'active_model'
 
 require 'cli'
 require 'domain'

--- a/lib/cloudware/aws.rb
+++ b/lib/cloudware/aws.rb
@@ -239,9 +239,6 @@ module Cloudware
       log.info("[#{self.class}] Deployment for #{name} finished, waiting for deployment to reach complete")
       @cfn.wait_until :stack_create_complete, stack_name: name
       log.info("[#{self.class}] Deployment for #{name} reached complete status")
-    # Catch errors and hand it up the stack for `cli.rb` to handle
-    rescue CloudFormation::Errors::ServiceError, Aws::Waiters::Errors::FailureStateError => error
-      raise error.message
     end
 
     def destroy(name, domain)

--- a/lib/cloudware/azure.rb
+++ b/lib/cloudware/azure.rb
@@ -67,7 +67,7 @@ module Cloudware
       Cloudware.log
     end
 
-    def create_domain(name, id, networkcidr, prvsubnetcidr, mgtsubnetcidr, region)
+    def create_domain(name, id, networkcidr, prvsubnetcidr, region)
       raise('Domain already exists') if resource_group_exists?(name)
       create_resource_group(region, id, name)
       params = {
@@ -75,7 +75,6 @@ module Cloudware
         cloudwareId: id,
         networkCIDR: networkcidr,
         prvSubnetCIDR: prvsubnetcidr,
-        mgtSubnetCIDR: mgtsubnetcidr,
       }
       deploy(name, 'domain', 'domain', params)
     end
@@ -95,7 +94,6 @@ module Cloudware
                               id: r.tags['cloudware_id'],
                               network_cidr: r.tags['cloudware_network_cidr'],
                               prv_subnet_cidr: r.tags['cloudware_prv_subnet_cidr'],
-                              mgt_subnet_cidr: r.tags['cloudware_mgt_subnet_cidr'],
                               provider: 'azure',
                               region: r.tags['cloudware_domain_region'],
                             })
@@ -105,7 +103,7 @@ module Cloudware
       end
     end
 
-    def create_machine(name, domain, id, prvip, mgtip, type, size, region, flavour)
+    def create_machine(name, domain, id, prvip, type, size, region, flavour)
       rg = "#{domain}-#{name}"
       abort('Machine already exists') if resource_group_exists?(rg)
       create_resource_group(region, id, rg)
@@ -115,7 +113,6 @@ module Cloudware
         vmName: name,
         vmType: size,
         prvSubnetIp: prvip,
-        mgtSubnetIp: mgtip,
         vmFlavour: flavour,
       }
       deploy(rg, name, "machine-#{type}", params)
@@ -140,7 +137,6 @@ module Cloudware
                                domain: r.tags['cloudware_domain'],
                                role: r.tags['cloudware_machine_role'],
                                prv_ip: r.tags['cloudware_prv_ip'],
-                               mgt_ip: r.tags['cloudware_mgt_ip'],
                                ext_ip: ext_ip,
                                provider: 'azure',
                                type: r.tags['cloudware_machine_type'],

--- a/lib/cloudware/azure.rb
+++ b/lib/cloudware/azure.rb
@@ -67,14 +67,14 @@ module Cloudware
       Cloudware.log
     end
 
-    def create_domain(name, id, networkcidr, prvsubnetcidr, region)
+    def create_domain(name, id, networkcidr, prisubnetcidr, region)
       raise('Domain already exists') if resource_group_exists?(name)
       create_resource_group(region, id, name)
       params = {
         cloudwareDomain: name,
         cloudwareId: id,
         networkCIDR: networkcidr,
-        prvSubnetCIDR: prvsubnetcidr,
+        priSubnetCIDR: prisubnetcidr,
       }
       deploy(name, 'domain', 'domain', params)
     end
@@ -93,7 +93,7 @@ module Cloudware
                               domain: r.tags['cloudware_domain'],
                               id: r.tags['cloudware_id'],
                               network_cidr: r.tags['cloudware_network_cidr'],
-                              prv_subnet_cidr: r.tags['cloudware_prv_subnet_cidr'],
+                              pri_subnet_cidr: r.tags['cloudware_pri_subnet_cidr'],
                               provider: 'azure',
                               region: r.tags['cloudware_domain_region'],
                             })
@@ -103,7 +103,7 @@ module Cloudware
       end
     end
 
-    def create_machine(name, domain, id, prvip, type, size, region, flavour)
+    def create_machine(name, domain, id, priip, type, size, region, flavour)
       rg = "#{domain}-#{name}"
       abort('Machine already exists') if resource_group_exists?(rg)
       create_resource_group(region, id, rg)
@@ -112,7 +112,7 @@ module Cloudware
         cloudwareId: id,
         vmName: name,
         vmType: size,
-        prvSubnetIp: prvip,
+        priSubnetIp: priip,
         vmFlavour: flavour,
       }
       deploy(rg, name, "machine-#{type}", params)
@@ -136,7 +136,7 @@ module Cloudware
                                id: r.tags['cloudware_id'],
                                domain: r.tags['cloudware_domain'],
                                role: r.tags['cloudware_machine_role'],
-                               prv_ip: r.tags['cloudware_prv_ip'],
+                               pri_ip: r.tags['cloudware_pri_ip'],
                                ext_ip: ext_ip,
                                provider: 'azure',
                                type: r.tags['cloudware_machine_type'],

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -52,6 +52,11 @@ module Cloudware
       end
     end
 
+    def self.cli_syntax(command, args_str = '')
+      s = "flightconnector #{command.name} #{args_str} [options]".squish
+      command.syntax = s
+    end
+
     command :domain do |c|
       c.syntax = 'flightconnector domain [options]'
       c.description = 'Manage a domain'
@@ -59,7 +64,7 @@ module Cloudware
     end
 
     command :'domain create' do |c|
-      c.syntax = 'flightconnector domain create NAME [options]'
+      cli_syntax(c, 'NAME')
       c.description = 'Create a new domain'
       c.option '--networkcidr CIDR', String, { default: '10.0.0.0/16' }, 'Entire network CIDR. The prv and mgt subnet must be within this range'
       c.option '-p', '--provider NAME', String, 'Cloud service provider name'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -63,8 +63,8 @@ module Cloudware
       c.description = 'Create a new domain'
       c.option '--networkcidr CIDR', String, { default: '10.0.0.0/16' }, 'Entire network CIDR. The prv and mgt subnet must be within this range'
       c.option '--provider NAME', String, 'Cloud service provider name'
-      c.option '--prvsubnetcidr NAME', String, 'Prv subnet CIDR'
-      c.option '--mgtsubnetcidr NAME', String, 'Mgt subnet CIDR'
+      c.option '--prvsubnetcidr NAME', { default: '10.0.1.0/24' }, String, 'Prv subnet CIDR'
+      c.option '--mgtsubnetcidr NAME', { default: '10.0.2.0/24' }, String, 'Mgt subnet CIDR'
       c.option '--region NAME', String, 'Provider region to create domain in'
       c.hidden = true
       action(c, Commands::Domain::Create)

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -66,22 +66,22 @@ module Cloudware
     command :'domain create' do |c|
       cli_syntax(c, 'NAME')
       c.description = 'Create a new domain'
+      c.option '-p', '--provider NAME', String,
+               'REQUIRED: Cloud service provider name'
+      c.option '-r', '--region NAME', String,
+               'REQUIRED: Provider region to create domain in'
       c.option '--networkcidr CIDR',
                String, { default: '10.0.0.0/16' },
                <<~SUMMARY.squish
                  Entire network CIDR. The prv and mgt subnet must be
                  within this range'
                SUMMARY
-      c.option '-p', '--provider NAME',
-               String, 'Cloud service provider name'
       c.option '--prvsubnetcidr NAME',
                String, { default: '10.0.1.0/24' },
                'Prv subnet CIDR'
       c.option '--mgtsubnetcidr NAME',
                String, { default: '10.0.2.0/24' },
                'Mgt subnet CIDR'
-      c.option '-r', '--region NAME', String,
-               'Provider region to create domain in'
       c.hidden = true
       action(c, Commands::Domain::Create)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -66,11 +66,22 @@ module Cloudware
     command :'domain create' do |c|
       cli_syntax(c, 'NAME')
       c.description = 'Create a new domain'
-      c.option '--networkcidr CIDR', String, { default: '10.0.0.0/16' }, 'Entire network CIDR. The prv and mgt subnet must be within this range'
-      c.option '-p', '--provider NAME', String, 'Cloud service provider name'
-      c.option '--prvsubnetcidr NAME', { default: '10.0.1.0/24' }, String, 'Prv subnet CIDR'
-      c.option '--mgtsubnetcidr NAME', { default: '10.0.2.0/24' }, String, 'Mgt subnet CIDR'
-      c.option '-r', '--region NAME', String, 'Provider region to create domain in'
+      c.option '--networkcidr CIDR',
+               String, { default: '10.0.0.0/16' },
+               <<~SUMMARY.squish
+                 Entire network CIDR. The prv and mgt subnet must be
+                 within this range'
+               SUMMARY
+      c.option '-p', '--provider NAME',
+               String, 'Cloud service provider name'
+      c.option '--prvsubnetcidr NAME',
+               String, { default: '10.0.1.0/24' },
+               'Prv subnet CIDR'
+      c.option '--mgtsubnetcidr NAME',
+               String, { default: '10.0.2.0/24' },
+               'Mgt subnet CIDR'
+      c.option '-r', '--region NAME', String,
+               'Provider region to create domain in'
       c.hidden = true
       action(c, Commands::Domain::Create)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -62,10 +62,10 @@ module Cloudware
       c.syntax = 'flightconnector domain create NAME [options]'
       c.description = 'Create a new domain'
       c.option '--networkcidr CIDR', String, { default: '10.0.0.0/16' }, 'Entire network CIDR. The prv and mgt subnet must be within this range'
-      c.option '--provider NAME', String, 'Cloud service provider name'
+      c.option '-p', '--provider NAME', String, 'Cloud service provider name'
       c.option '--prvsubnetcidr NAME', { default: '10.0.1.0/24' }, String, 'Prv subnet CIDR'
       c.option '--mgtsubnetcidr NAME', { default: '10.0.2.0/24' }, String, 'Mgt subnet CIDR'
-      c.option '--region NAME', String, 'Provider region to create domain in'
+      c.option '-r', '--region NAME', String, 'Provider region to create domain in'
       c.hidden = true
       action(c, Commands::Domain::Create)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -27,9 +27,11 @@ require 'colorize'
 require 'whirly'
 require 'exceptions'
 require 'command'
+require 'models/application'
 
 require 'require_all'
 require_all 'lib/cloudware/commands/**/*.rb'
+require_all 'lib/cloudware/models/**/*.rb'
 
 module Cloudware
   class CLI

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -73,12 +73,12 @@ module Cloudware
       c.option '--networkcidr CIDR',
                String, { default: '10.0.0.0/16' },
                <<~SUMMARY.squish
-                 Entire network CIDR. The prv and mgt subnet must be
+                 Entire network CIDR. The pri and mgt subnet must be
                  within this range'
                SUMMARY
-      c.option '--prvsubnetcidr NAME',
+      c.option '--prisubnetcidr NAME',
                String, { default: '10.0.1.0/24' },
-               'Prv subnet CIDR'
+               'Pri subnet CIDR'
       c.hidden = true
       action(c, Commands::Domain::Create)
     end
@@ -112,7 +112,7 @@ module Cloudware
       c.option '--name NAME', String, 'Machine name'
       c.option '--domain NAME', String, 'Domain name'
       c.option '--role NAME', String, 'Machine role to inherit (master or slave)'
-      c.option '--prvip ADDR', String, 'Prv subnet IP address'
+      c.option '--priip ADDR', String, 'Pri subnet IP address'
       c.option '--type NAME', String, 'Flavour of machine type to deploy, e.g. medium'
       c.option '--flavour NAME', String, 'Type of machine to deploy, e.g. gpu'
       c.hidden = true

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -41,6 +41,8 @@ module Cloudware
     program :version, '0.0.1'
     program :description, 'Cloud orchestration tool'
 
+    suppress_trace_class UserError
+
     # Display the help if there is no input arguments
     ARGV.push '--help' if ARGV.empty?
 

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -79,9 +79,6 @@ module Cloudware
       c.option '--prvsubnetcidr NAME',
                String, { default: '10.0.1.0/24' },
                'Prv subnet CIDR'
-      c.option '--mgtsubnetcidr NAME',
-               String, { default: '10.0.2.0/24' },
-               'Mgt subnet CIDR'
       c.hidden = true
       action(c, Commands::Domain::Create)
     end
@@ -116,7 +113,6 @@ module Cloudware
       c.option '--domain NAME', String, 'Domain name'
       c.option '--role NAME', String, 'Machine role to inherit (master or slave)'
       c.option '--prvip ADDR', String, 'Prv subnet IP address'
-      c.option '--mgtip ADDR', String, 'Mgt subnet IP address'
       c.option '--type NAME', String, 'Flavour of machine type to deploy, e.g. medium'
       c.option '--flavour NAME', String, 'Type of machine to deploy, e.g. gpu'
       c.hidden = true

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -57,9 +57,8 @@ module Cloudware
     end
 
     command :'domain create' do |c|
-      c.syntax = 'flightconnector domain create [options]'
+      c.syntax = 'flightconnector domain create NAME [options]'
       c.description = 'Create a new domain'
-      c.option '--name NAME', String, 'Name of cloud domain'
       c.option '--networkcidr CIDR', String, 'Entire network CIDR, e.g. 10.0.0.0/16. The prv and mgt subnet must be within this range'
       c.option '--provider NAME', String, 'Cloud service provider name'
       c.option '--prvsubnetcidr NAME', String, 'Prv subnet CIDR'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -23,7 +23,6 @@
 #==============================================================================
 require 'commander'
 require 'terminal-table'
-require 'colorize'
 require 'whirly'
 require 'exceptions'
 require 'command'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -61,7 +61,7 @@ module Cloudware
     command :'domain create' do |c|
       c.syntax = 'flightconnector domain create NAME [options]'
       c.description = 'Create a new domain'
-      c.option '--networkcidr CIDR', String, 'Entire network CIDR, e.g. 10.0.0.0/16. The prv and mgt subnet must be within this range'
+      c.option '--networkcidr CIDR', String, { default: '10.0.0.0/16' }, 'Entire network CIDR. The prv and mgt subnet must be within this range'
       c.option '--provider NAME', String, 'Cloud service provider name'
       c.option '--prvsubnetcidr NAME', String, 'Prv subnet CIDR'
       c.option '--mgtsubnetcidr NAME', String, 'Mgt subnet CIDR'

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -16,7 +16,7 @@ module Cloudware
     end
 
     def unpack_args; end
-    def enforce_required_options; end
+    def required_options; end
 
     def run
       raise NotImplementedError
@@ -29,6 +29,9 @@ module Cloudware
     def handle_fatal_error(e)
       Cloudware.log.fatal(e.message)
       raise e
+    end
+
+    def enforce_required_options
     end
 
     def run_whirly(status)

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -16,6 +16,7 @@ module Cloudware
     end
 
     def unpack_args; end
+
     def required_options; end
 
     def run

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -33,7 +33,7 @@ module Cloudware
 
     def enforce_required_options
       required_options&.each do |opt|
-        next if options[opt]
+        next if options.method_missing(opt)
         raise InvalidInput, <<-ERROR.squish
           Missing the required --#{opt} input
         ERROR

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -9,12 +9,14 @@ module Cloudware
 
     def run!
       unpack_args
+      enforce_required_options
       run
     rescue Exception => e
       handle_fatal_error(e)
     end
 
     def unpack_args; end
+    def enforce_required_options; end
 
     def run
       raise NotImplementedError

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -28,5 +28,11 @@ module Cloudware
       Cloudware.log.fatal(e.message)
       raise e
     end
+
+    def run_whirly(status)
+      Whirly.start status: status do
+        yield if block_given?
+      end
+    end
   end
 end

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -32,6 +32,12 @@ module Cloudware
     end
 
     def enforce_required_options
+      required_options&.each do |opt|
+        next if options[opt]
+        raise InvalidInput, <<-ERROR.squish
+          Missing the required --#{opt} input
+        ERROR
+      end
     end
 
     def run_whirly(status)

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -30,8 +30,10 @@ module Cloudware
     end
 
     def run_whirly(status)
-      Whirly.start status: status do
-        yield if block_given?
+      update_status = proc { |s| Whirly.status = s.bold }
+      Whirly.start do
+        update_status.call(status)
+        yield update_status if block_given?
       end
     end
   end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -10,14 +10,12 @@ module Cloudware
           d.region = options.region
           d.networkcidr = options.networkcidr
           d.prvsubnetcidr = options.prvsubnetcidr
-          d.mgtsubnetcidr = options.mgtsubnetcidr
 
           run_whirly('Verifying network CIDR is valid') do |update_status|
             raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
             update_status.call('Verifying prv subnet CIDR is valid')
             raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
             update_status.call('Verifying mgt subnet CIDR is valid')
-            raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           end
 
           run_whirly('Checking domain name is valid') do

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -7,6 +7,7 @@ module Cloudware
         def run
           d = Cloudware::Domain.new
           d.name = name
+          d.region = options.region
 
           options.networkcidr = ask('Network CIDR: ') if options.networkcidr.nil?
           d.networkcidr = options.networkcidr.to_s

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -24,7 +24,7 @@ module Cloudware
           options.mgtsubnetcidr = ask('Mgt subnet CIDR: ') if options.mgtsubnetcidr.nil?
           d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
 
-          Whirly.start status: 'Verifying network CIDR is valid' do
+          run_whirly('Verifying network CIDR is valid') do
             raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
             Whirly.status = 'Verifying prv subnet CIDR is valid'
             raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
@@ -32,18 +32,18 @@ module Cloudware
             raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           end
 
-          Whirly.start status: 'Checking domain name is valid' do
+          run_whirly('Checking domain name is valid') do
             raise("Domain name #{options.name} is not valid") unless d.valid_name?
           end
 
-          Whirly.start status: 'Checking domain does not already exist' do
+          run_whirly('Checking domain does not already exist') do
             raise("Domain name #{options.name} already exists") if d.exists?
             d.provider = options.provider.to_s
             Whirly.status = 'Verifying provider is valid'
             raise("Provider #{options.provider} does not exist") unless d.valid_provider?
           end
 
-          Whirly.start status: 'Creating new deployment' do
+          run_whirly('Creating new deployment') do
             d.create
           end
         end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -6,9 +6,7 @@ module Cloudware
       class Create < Command
         def run
           d = Cloudware::Domain.new
-
-          options.name = ask('Domain identifier: ') if options.name.nil?
-          d.name = options.name.to_s
+          d.name = name
 
           options.provider = choose('Provider name?', :aws, :azure, :gcp) if options.provider.nil?
 
@@ -47,6 +45,14 @@ module Cloudware
             d.create
           end
         end
+
+        def unpack_args
+          @name = args.first
+        end
+
+        private
+
+        attr_reader :name
       end
     end
   end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -13,11 +13,11 @@ module Cloudware
           d.mgtsubnetcidr = options.mgtsubnetcidr
 
           run_whirly('Verifying network CIDR is valid') do |update_status|
-            # raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
+            raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
             update_status.call('Verifying prv subnet CIDR is valid')
-            # raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
+            raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
             update_status.call('Verifying mgt subnet CIDR is valid')
-            # raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
+            raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           end
 
           run_whirly('Checking domain name is valid') do

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -24,28 +24,28 @@ module Cloudware
           options.mgtsubnetcidr = ask('Mgt subnet CIDR: ') if options.mgtsubnetcidr.nil?
           d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
 
-          Whirly.start status: 'Verifying network CIDR is valid'
-          raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
-          Whirly.status = 'Verifying prv subnet CIDR is valid'
-          raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
-          Whirly.status = 'Verifying mgt subnet CIDR is valid'
-          raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
-          Whirly.stop
+          Whirly.start status: 'Verifying network CIDR is valid' do
+            raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
+            Whirly.status = 'Verifying prv subnet CIDR is valid'
+            raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
+            Whirly.status = 'Verifying mgt subnet CIDR is valid'
+            raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
+          end
 
-          Whirly.start status: 'Checking domain name is valid'
-          raise("Domain name #{options.name} is not valid") unless d.valid_name?
-          Whirly.stop
+          Whirly.start status: 'Checking domain name is valid' do
+            raise("Domain name #{options.name} is not valid") unless d.valid_name?
+          end
 
-          Whirly.start status: 'Checking domain does not already exist'
-          raise("Domain name #{options.name} already exists") if d.exists?
-          d.provider = options.provider.to_s
-          Whirly.status = 'Verifying provider is valid'
-          raise("Provider #{options.provider} does not exist") unless d.valid_provider?
-          Whirly.stop
+          Whirly.start status: 'Checking domain does not already exist' do
+            raise("Domain name #{options.name} already exists") if d.exists?
+            d.provider = options.provider.to_s
+            Whirly.status = 'Verifying provider is valid'
+            raise("Provider #{options.provider} does not exist") unless d.valid_provider?
+          end
 
-          Whirly.start status: 'Creating new deployment'
-          d.create
-          Whirly.stop
+          Whirly.start status: 'Creating new deployment' do
+            d.create
+          end
         end
       end
     end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -18,11 +18,11 @@ module Cloudware
           d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
 
           run_whirly('Verifying network CIDR is valid') do |update_status|
-            raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
+            # raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
             update_status.call('Verifying prv subnet CIDR is valid')
-            raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
+            # raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
             update_status.call('Verifying mgt subnet CIDR is valid')
-            raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
+            # raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           end
 
           run_whirly('Checking domain name is valid') do

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -14,7 +14,7 @@ module Cloudware
           run_whirly('Verifying network CIDR is valid') do |update_status|
             raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
             update_status.call('Verifying pri subnet CIDR is valid')
-            raise("Prv subnet CIDR #{options.prisubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prisubnetcidr.to_s)
+            raise("Pri subnet CIDR #{options.prisubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prisubnetcidr.to_s)
             update_status.call('Verifying mgt subnet CIDR is valid')
           end
 

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -8,15 +8,9 @@ module Cloudware
           d = Cloudware::Domain.new
           d.name = name
           d.region = options.region
-
-          options.networkcidr = ask('Network CIDR: ') if options.networkcidr.nil?
-          d.networkcidr = options.networkcidr.to_s
-
-          options.prvsubnetcidr = ask('Prv subnet CIDR: ') if options.prvsubnetcidr.nil?
-          d.prvsubnetcidr = options.prvsubnetcidr.to_s
-
-          options.mgtsubnetcidr = ask('Mgt subnet CIDR: ') if options.mgtsubnetcidr.nil?
-          d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
+          d.networkcidr = options.networkcidr
+          d.prvsubnetcidr = options.prvsubnetcidr
+          d.mgtsubnetcidr = options.mgtsubnetcidr
 
           run_whirly('Verifying network CIDR is valid') do |update_status|
             # raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -9,12 +9,12 @@ module Cloudware
           d.name = name
           d.region = options.region
           d.networkcidr = options.networkcidr
-          d.prvsubnetcidr = options.prvsubnetcidr
+          d.prisubnetcidr = options.prisubnetcidr
 
           run_whirly('Verifying network CIDR is valid') do |update_status|
             raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
-            update_status.call('Verifying prv subnet CIDR is valid')
-            raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
+            update_status.call('Verifying pri subnet CIDR is valid')
+            raise("Prv subnet CIDR #{options.prisubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prisubnetcidr.to_s)
             update_status.call('Verifying mgt subnet CIDR is valid')
           end
 

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -24,26 +24,26 @@ module Cloudware
           options.mgtsubnetcidr = ask('Mgt subnet CIDR: ') if options.mgtsubnetcidr.nil?
           d.mgtsubnetcidr = options.mgtsubnetcidr.to_s
 
-          run_whirly('Verifying network CIDR is valid') do
+          run_whirly('Verifying network CIDR is valid') do |update_status|
             raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
-            Whirly.status = 'Verifying prv subnet CIDR is valid'
+            update_status.call('Verifying prv subnet CIDR is valid')
             raise("Prv subnet CIDR #{options.prvsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prvsubnetcidr.to_s)
-            Whirly.status = 'Verifying mgt subnet CIDR is valid'
+            update_status.call('Verifying mgt subnet CIDR is valid')
             raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           end
 
-          run_whirly('Checking domain name is valid') do
+          run_whirly('Checking domain name is valid') do |update_status|
             raise("Domain name #{options.name} is not valid") unless d.valid_name?
           end
 
-          run_whirly('Checking domain does not already exist') do
+          run_whirly('Checking domain does not already exist') do |update_status|
             raise("Domain name #{options.name} already exists") if d.exists?
             d.provider = options.provider.to_s
-            Whirly.status = 'Verifying provider is valid'
+            update_status.call('Verifying provider is valid')
             raise("Provider #{options.provider} does not exist") unless d.valid_provider?
           end
 
-          run_whirly('Creating new deployment') do
+          run_whirly('Creating new deployment') do |update_status|
             d.create
           end
         end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -8,6 +8,7 @@ module Cloudware
           d = Cloudware::Domain.new
           d.name = name
           d.region = options.region
+          d.provider = options.provider
           d.networkcidr = options.networkcidr
           d.prisubnetcidr = options.prisubnetcidr
 
@@ -24,7 +25,6 @@ module Cloudware
 
           run_whirly('Checking domain does not already exist') do |update_status|
             raise("Domain name #{options.name} already exists") if d.exists?
-            d.provider = options.provider.to_s
             update_status.call('Verifying provider is valid')
             raise("Provider #{options.provider} does not exist") unless d.valid_provider?
           end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -16,7 +16,6 @@ module Cloudware
             raise("Network CIDR #{options.networkcidr} is not a valid IPV4 address") unless d.valid_cidr?(options.networkcidr.to_s)
             update_status.call('Verifying pri subnet CIDR is valid')
             raise("Pri subnet CIDR #{options.prisubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.prisubnetcidr.to_s)
-            update_status.call('Verifying mgt subnet CIDR is valid')
           end
 
           run_whirly('Checking domain name is valid') do

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -32,7 +32,7 @@ module Cloudware
             raise("Mgt subnet CIDR #{options.mgtsubnetcidr} is not valid for network cidr #{options.networkcidr}") unless d.is_valid_subnet_cidr?(options.networkcidr.to_s, options.mgtsubnetcidr.to_s)
           end
 
-          run_whirly('Checking domain name is valid') do |update_status|
+          run_whirly('Checking domain name is valid') do
             raise("Domain name #{options.name} is not valid") unless d.valid_name?
           end
 
@@ -43,7 +43,7 @@ module Cloudware
             raise("Provider #{options.provider} does not exist") unless d.valid_provider?
           end
 
-          run_whirly('Creating new deployment') do |update_status|
+          run_whirly('Creating new deployment') do
             d.create
           end
         end

--- a/lib/cloudware/commands/domain/create.rb
+++ b/lib/cloudware/commands/domain/create.rb
@@ -8,11 +8,6 @@ module Cloudware
           d = Cloudware::Domain.new
           d.name = name
 
-          options.provider = choose('Provider name?', :aws, :azure, :gcp) if options.provider.nil?
-
-          options.region = ask('Provider region: ') if options.region.nil?
-          d.region = options.region.to_s
-
           options.networkcidr = ask('Network CIDR: ') if options.networkcidr.nil?
           d.networkcidr = options.networkcidr.to_s
 
@@ -48,6 +43,10 @@ module Cloudware
 
         def unpack_args
           @name = args.first
+        end
+
+        def required_options
+          [:provider, :region]
         end
 
         private

--- a/lib/cloudware/commands/domain/destroy.rb
+++ b/lib/cloudware/commands/domain/destroy.rb
@@ -10,11 +10,11 @@ module Cloudware
           options.name = ask('Domain name: ') if options.name.nil?
           d.name = options.name.to_s
 
-          Whirly.start status: 'Checking domain exists' do
+          run_whirly('Checking domain exists') do
             raise("Domain name #{options.name} does not exist") unless d.exists?
           end
 
-          Whirly.start status: "Destroying domain #{options.name}" do
+          run_whirly("Destroying domain #{options.name}") do
             d.destroy
           end
         end

--- a/lib/cloudware/commands/domain/destroy.rb
+++ b/lib/cloudware/commands/domain/destroy.rb
@@ -10,13 +10,13 @@ module Cloudware
           options.name = ask('Domain name: ') if options.name.nil?
           d.name = options.name.to_s
 
-          Whirly.start status: 'Checking domain exists'
-          raise("Domain name #{options.name} does not exist") unless d.exists?
-          Whirly.stop
+          Whirly.start status: 'Checking domain exists' do
+            raise("Domain name #{options.name} does not exist") unless d.exists?
+          end
 
-          Whirly.start status: "Destroying domain #{options.name}"
-          d.destroy
-          Whirly.stop
+          Whirly.start status: "Destroying domain #{options.name}" do
+            d.destroy
+          end
         end
       end
     end

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -6,7 +6,8 @@ module Cloudware
       class List < Command
         def run
           d = Cloudware::Domain.new
-          d.provider = [options.provider] unless options.provider.nil?
+          # TODO: Why does this need to be wrapped?
+          d.provider = Array.wrap(options.provider)
           d.region = options.region.to_s unless options.region.nil?
           d.name = options.name.to_s unless options.name.nil?
 
@@ -29,6 +30,10 @@ module Cloudware
                                                  'Region'.bold],
                                       rows: r
           puts table
+        end
+
+        def required_options
+          [:provider]
         end
       end
     end

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -16,9 +16,9 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available domains'
-          raise('No available domains') if d.list.nil?
-          Whirly.stop
+          Whirly.start status: 'Fetching available domains' do
+            raise('No available domains') if d.list.nil?
+          end
           d.list.each do |k, v|
             r << [k, v[:network_cidr], v[:prv_subnet_cidr], v[:mgt_subnet_cidr], v[:provider], v[:region]]
           end

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -18,9 +18,9 @@ module Cloudware
 
           r = []
           run_whirly('Fetching available domains') do
-            raise('No available domains') if d.list.nil?
+            raise('No available domains') if Domains.list.nil?
           end
-          d.list.each do |k, v|
+          Domains.list.each do |k, v|
             r << [k, v[:network_cidr], v[:pri_subnet_cidr], v[:provider], v[:region]]
           end
           table = Terminal::Table.new headings: ['Domain name'.bold,

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -20,12 +20,11 @@ module Cloudware
             raise('No available domains') if d.list.nil?
           end
           d.list.each do |k, v|
-            r << [k, v[:network_cidr], v[:prv_subnet_cidr], v[:mgt_subnet_cidr], v[:provider], v[:region]]
+            r << [k, v[:network_cidr], v[:prv_subnet_cidr], v[:provider], v[:region]]
           end
           table = Terminal::Table.new headings: ['Domain name'.bold,
                                                  'Network CIDR'.bold,
                                                  'Prv Subnet CIDR'.bold,
-                                                 'Mgt Subnet CIDR'.bold,
                                                  'Provider'.bold,
                                                  'Region'.bold],
                                       rows: r

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -20,11 +20,11 @@ module Cloudware
             raise('No available domains') if d.list.nil?
           end
           d.list.each do |k, v|
-            r << [k, v[:network_cidr], v[:prv_subnet_cidr], v[:provider], v[:region]]
+            r << [k, v[:network_cidr], v[:pri_subnet_cidr], v[:provider], v[:region]]
           end
           table = Terminal::Table.new headings: ['Domain name'.bold,
                                                  'Network CIDR'.bold,
-                                                 'Prv Subnet CIDR'.bold,
+                                                 'Pri Subnet CIDR'.bold,
                                                  'Provider'.bold,
                                                  'Region'.bold],
                                       rows: r

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -16,7 +16,7 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available domains' do
+          run_whirly('Fetching available domains') do
             raise('No available domains') if d.list.nil?
           end
           d.list.each do |k, v|

--- a/lib/cloudware/commands/domain/list.rb
+++ b/lib/cloudware/commands/domain/list.rb
@@ -11,7 +11,7 @@ module Cloudware
           d.name = options.name.to_s unless options.name.nil?
 
           # Exit if the provider is not in the config list (which verifies details ahead of time)
-          if (Cloudware.config.instance_variable_get(:@providers) & d.provider).empty?
+          if (Cloudware.config.providers & d.provider).empty?
             raise "The provider #{d.provider.join(',')} is not a valid provider - unknown or missing login details"
           end
 

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,11 +29,11 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          Whirly.start status: 'Verifying domain exists' do
+          run_whirly('Verifying domain exists') do
             raise("Domain #{options.domain} does not exist") unless m.valid_domain?
           end
 
-          Whirly.start status: 'Checking machine name is valid' do
+          run_whirly('Checking machine name is valid') do
             raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
             Whirly.status = 'Verifying prv IP address'
             raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
@@ -41,7 +41,7 @@ module Cloudware
             raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
           end
 
-          Whirly.start status: 'Creating new deployment' do
+          run_whirly('Creating new deployment') do
             m.create
           end
         end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,19 +29,19 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          run_whirly('Verifying domain exists') do
+          run_whirly('Verifying domain exists') do |update_status|
             raise("Domain #{options.domain} does not exist") unless m.valid_domain?
           end
 
-          run_whirly('Checking machine name is valid') do
+          run_whirly('Checking machine name is valid') do |update_status|
             raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
-            Whirly.status = 'Verifying prv IP address'
+            update_status.call('Verifying prv IP address')
             raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
-            Whirly.status = 'Verifying mgt IP address'
+            update_status.call('Verifying mgt IP address')
             raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
           end
 
-          run_whirly('Creating new deployment') do
+          run_whirly('Creating new deployment') do |update_status|
             m.create
           end
         end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,7 +29,7 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          run_whirly('Verifying domain exists') do |update_status|
+          run_whirly('Verifying domain exists') do
             raise("Domain #{options.domain} does not exist") unless m.valid_domain?
           end
 
@@ -41,7 +41,7 @@ module Cloudware
             raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
           end
 
-          run_whirly('Creating new deployment') do |update_status|
+          run_whirly('Creating new deployment') do
             m.create
           end
         end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -23,8 +23,8 @@ module Cloudware
           options.role = choose('Machine role?', :master, :slave) if options.role.nil?
           m.role = options.role.to_s
 
-          options.prvip = ask('Prv subnet IP: ') if options.prvip.nil?
-          m.prvip = options.prvip.to_s
+          options.priip = ask('Pri subnet IP: ') if options.priip.nil?
+          m.priip = options.priip.to_s
 
           run_whirly('Verifying domain exists') do
             raise("Domain #{options.domain} does not exist") unless m.valid_domain?
@@ -32,8 +32,8 @@ module Cloudware
 
           run_whirly('Checking machine name is valid') do |update_status|
             raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
-            update_status.call('Verifying prv IP address')
-            raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
+            update_status.call('Verifying pri IP address')
+            raise("Invalid pri IP address #{options.priip} in subnet #{d.get_item('pri_subnet_cidr')}") unless m.valid_ip?(d.get_item('pri_subnet_cidr').to_s, options.priip.to_s)
             update_status.call('Verifying mgt IP address')
           end
 

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -26,9 +26,6 @@ module Cloudware
           options.prvip = ask('Prv subnet IP: ') if options.prvip.nil?
           m.prvip = options.prvip.to_s
 
-          options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
-          m.mgtip = options.mgtip.to_s
-
           run_whirly('Verifying domain exists') do
             raise("Domain #{options.domain} does not exist") unless m.valid_domain?
           end
@@ -38,7 +35,6 @@ module Cloudware
             update_status.call('Verifying prv IP address')
             raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
             update_status.call('Verifying mgt IP address')
-            raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
           end
 
           run_whirly('Creating new deployment') do

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -29,21 +29,21 @@ module Cloudware
           options.mgtip = ask('Mgt subnet IP: ') if options.mgtip.nil?
           m.mgtip = options.mgtip.to_s
 
-          Whirly.start status: 'Verifying domain exists'
-          raise("Domain #{options.domain} does not exist") unless m.valid_domain?
-          Whirly.stop
+          Whirly.start status: 'Verifying domain exists' do
+            raise("Domain #{options.domain} does not exist") unless m.valid_domain?
+          end
 
-          Whirly.start status: 'Checking machine name is valid'
-          raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
-          Whirly.status = 'Verifying prv IP address'
-          raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
-          Whirly.status = 'Verifying mgt IP address'
-          raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
-          Whirly.stop
+          Whirly.start status: 'Checking machine name is valid' do
+            raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
+            Whirly.status = 'Verifying prv IP address'
+            raise("Invalid prv IP address #{options.prvip} in subnet #{d.get_item('prv_subnet_cidr')}") unless m.valid_ip?(d.get_item('prv_subnet_cidr').to_s, options.prvip.to_s)
+            Whirly.status = 'Verifying mgt IP address'
+            raise("Invalid mgt IP address #{options.mgtip} in subnet #{d.get_item('mgt_subnet_cidr')}") unless m.valid_ip?(d.get_item('mgt_subnet_cidr').to_s, options.mgtip.to_s)
+          end
 
-          Whirly.start status: 'Creating new deployment'
-          m.create
-          Whirly.stop
+          Whirly.start status: 'Creating new deployment' do
+            m.create
+          end
         end
       end
     end

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -13,13 +13,13 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           m.domain = options.domain.to_s
 
-          Whirly.start status: 'Checking machine exists'
-          raise('Machine does not exist') unless m.exists?
-          Whirly.stop
+          Whirly.start status: 'Checking machine exists' do
+            raise('Machine does not exist') unless m.exists?
+          end
 
-          Whirly.start status: "Destroying #{options.name} in domain #{options.domain}"
-          m.destroy
-          Whirly.stop
+          Whirly.start status: "Destroying #{options.name} in domain #{options.domain}" do
+            m.destroy
+          end
         end
       end
     end

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -13,11 +13,11 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           m.domain = options.domain.to_s
 
-          Whirly.start status: 'Checking machine exists' do
+          run_whirly('Checking machine exists') do
             raise('Machine does not exist') unless m.exists?
           end
 
-          Whirly.start status: "Destroying #{options.name} in domain #{options.domain}" do
+          run_whirly("Destroying #{options.name} in domain #{options.domain}") do
             m.destroy
           end
         end

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -19,7 +19,7 @@ module Cloudware
                 t.add_row ['Machine name'.bold, m.name]
                 t.add_row ['Domain name'.bold, m.get_item('domain')]
                 t.add_row ['Machine role'.bold, m.get_item('role')]
-                t.add_row ['Prv subnet IP'.bold, m.get_item('prv_ip')]
+                t.add_row ['Pri subnet IP'.bold, m.get_item('pri_ip')]
                 t.add_row ['External IP'.bold, m.get_item('ext_ip')]
                 t.add_row ['Machine state'.bold, m.get_item('state')]
                 t.add_row ['Machine type'.bold, m.get_item('type')]

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -15,18 +15,18 @@ module Cloudware
           case options.output.to_s
           when 'table'
             table = Terminal::Table.new do |t|
-              Whirly.start status: 'Fetching machine info'
-              t.add_row ['Machine name'.bold, m.name]
-              t.add_row ['Domain name'.bold, m.get_item('domain')]
-              t.add_row ['Machine role'.bold, m.get_item('role')]
-              t.add_row ['Prv subnet IP'.bold, m.get_item('prv_ip')]
-              t.add_row ['Mgt subnet IP'.bold, m.get_item('mgt_ip')]
-              t.add_row ['External IP'.bold, m.get_item('ext_ip')]
-              t.add_row ['Machine state'.bold, m.get_item('state')]
-              t.add_row ['Machine type'.bold, m.get_item('type')]
-              t.add_row ['Machine flavour'.bold, m.get_item('flavour')]
-              t.add_row ['Provider'.bold, m.get_item('provider')]
-              Whirly.stop
+              Whirly.start status: 'Fetching machine info' do
+                t.add_row ['Machine name'.bold, m.name]
+                t.add_row ['Domain name'.bold, m.get_item('domain')]
+                t.add_row ['Machine role'.bold, m.get_item('role')]
+                t.add_row ['Prv subnet IP'.bold, m.get_item('prv_ip')]
+                t.add_row ['Mgt subnet IP'.bold, m.get_item('mgt_ip')]
+                t.add_row ['External IP'.bold, m.get_item('ext_ip')]
+                t.add_row ['Machine state'.bold, m.get_item('state')]
+                t.add_row ['Machine type'.bold, m.get_item('type')]
+                t.add_row ['Machine flavour'.bold, m.get_item('flavour')]
+                t.add_row ['Provider'.bold, m.get_item('provider')]
+              end
               t.style = { all_separators: true }
             end
             puts table

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -15,7 +15,7 @@ module Cloudware
           case options.output.to_s
           when 'table'
             table = Terminal::Table.new do |t|
-              Whirly.start status: 'Fetching machine info' do
+              run_whirly('Fetching machine info') do
                 t.add_row ['Machine name'.bold, m.name]
                 t.add_row ['Domain name'.bold, m.get_item('domain')]
                 t.add_row ['Machine role'.bold, m.get_item('role')]

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -20,7 +20,6 @@ module Cloudware
                 t.add_row ['Domain name'.bold, m.get_item('domain')]
                 t.add_row ['Machine role'.bold, m.get_item('role')]
                 t.add_row ['Prv subnet IP'.bold, m.get_item('prv_ip')]
-                t.add_row ['Mgt subnet IP'.bold, m.get_item('mgt_ip')]
                 t.add_row ['External IP'.bold, m.get_item('ext_ip')]
                 t.add_row ['Machine state'.bold, m.get_item('state')]
                 t.add_row ['Machine type'.bold, m.get_item('type')]

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -14,7 +14,7 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available machines' do
+          run_whirly('Fetching available machines') do
             raise('No available machines') if m.list.nil?
           end
           m.list.each do |_k, v|

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -18,13 +18,12 @@ module Cloudware
             raise('No available machines') if m.list.nil?
           end
           m.list.each do |_k, v|
-            r << [v[:name], v[:domain], v[:role], v[:prv_ip], v[:mgt_ip], v[:type], v[:state]]
+            r << [v[:name], v[:domain], v[:role], v[:prv_ip], v[:type], v[:state]]
           end
           table = Terminal::Table.new headings: ['Name'.bold,
                                                  'Domain'.bold,
                                                  'Role'.bold,
                                                  'Prv IP address'.bold,
-                                                 'Mgt IP address'.bold,
                                                  'Type'.bold,
                                                  'State'.bold],
                                       rows: r

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -14,9 +14,9 @@ module Cloudware
           end
 
           r = []
-          Whirly.start status: 'Fetching available machines'
-          raise('No available machines') if m.list.nil?
-          Whirly.stop
+          Whirly.start status: 'Fetching available machines' do
+            raise('No available machines') if m.list.nil?
+          end
           m.list.each do |_k, v|
             r << [v[:name], v[:domain], v[:role], v[:prv_ip], v[:mgt_ip], v[:type], v[:state]]
           end

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -18,12 +18,12 @@ module Cloudware
             raise('No available machines') if m.list.nil?
           end
           m.list.each do |_k, v|
-            r << [v[:name], v[:domain], v[:role], v[:prv_ip], v[:type], v[:state]]
+            r << [v[:name], v[:domain], v[:role], v[:pri_ip], v[:type], v[:state]]
           end
           table = Terminal::Table.new headings: ['Name'.bold,
                                                  'Domain'.bold,
                                                  'Role'.bold,
-                                                 'Prv IP address'.bold,
+                                                 'Pri IP address'.bold,
                                                  'Type'.bold,
                                                  'State'.bold],
                                       rows: r

--- a/lib/cloudware/commands/machine/power/off.rb
+++ b/lib/cloudware/commands/machine/power/off.rb
@@ -13,9 +13,9 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering off machine #{options.name}"
-            machine.power_off
-            Whirly.stop
+            Whirly.start status: "Powering off machine #{options.name}" do
+              machine.power_off
+            end
           end
         end
       end

--- a/lib/cloudware/commands/machine/power/off.rb
+++ b/lib/cloudware/commands/machine/power/off.rb
@@ -13,7 +13,7 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering off machine #{options.name}" do
+            run_whirly("Powering off machine #{options.name}") do
               machine.power_off
             end
           end

--- a/lib/cloudware/commands/machine/power/on.rb
+++ b/lib/cloudware/commands/machine/power/on.rb
@@ -13,7 +13,7 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering on machine #{options.name}" do
+            run_whirly("Powering on machine #{options.name}") do
               machine.power_on
             end
           end

--- a/lib/cloudware/commands/machine/power/on.rb
+++ b/lib/cloudware/commands/machine/power/on.rb
@@ -13,9 +13,9 @@ module Cloudware
             options.domain = ask('Domain identifier: ') if options.domain.nil?
             machine.domain = options.domain.to_s
 
-            Whirly.start status: "Powering on machine #{options.name}"
-            machine.power_on
-            Whirly.stop
+            Whirly.start status: "Powering on machine #{options.name}" do
+              machine.power_on
+            end
           end
         end
       end

--- a/lib/cloudware/commands/machine/rebuild.rb
+++ b/lib/cloudware/commands/machine/rebuild.rb
@@ -12,7 +12,7 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           machine.domain = options.domain.to_s
 
-          Whirly.start status: "Recreating machine #{options.name}" do
+          run_whirly("Recreating machine #{options.name}") do
             machine.rebuild
           end
         end

--- a/lib/cloudware/commands/machine/rebuild.rb
+++ b/lib/cloudware/commands/machine/rebuild.rb
@@ -12,9 +12,9 @@ module Cloudware
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           machine.domain = options.domain.to_s
 
-          Whirly.start status: "Recreating machine #{options.name}"
-          machine.rebuild
-          Whirly.stop
+          Whirly.start status: "Recreating machine #{options.name}" do
+            machine.rebuild
+          end
         end
       end
     end

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -113,13 +113,9 @@ module Cloudware
                      end
     end
 
+    # TODO: What is this suppose to do?
     def has_machines?
-      machine = Cloudware::Machine.new
-      machine.list.each do |k, _v|
-        return false
-        return true if /#{@name}/.match?(k)
-        break
-      end
+      false
     end
 
     def exists?

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -55,7 +55,7 @@ module Cloudware
     def describe
       @describe ||= begin
                     domain = Struct.new :name, :region, :provider, :networkcidr, :prvsubnetcidr
-                    @describe = domain.new(get_item('domain'), get_item('region'), get_item('provider'), get_item('network_cidr'), get_item('prv_subnet_cidr')
+                    @describe = domain.new(get_item('domain'), get_item('region'), get_item('provider'), get_item('network_cidr'), get_item('prv_subnet_cidr'))
                   end
     end
 

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -60,7 +60,6 @@ module Cloudware
                     else
                       raise "Provider #{provider} doesn't exist"
                     end
-      log.debug("[#{self.class}] Loaded machines from #{provider}:\n#{local_cloud.domains}")
       local_cloud.domains
     end
 

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -37,7 +37,6 @@ module Cloudware
 
     def initialize
       @items = {}
-      @provider = Cloudware.config.instance_variable_get(:@providers)
     end
 
     def load_cloud

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -30,10 +30,10 @@ module Cloudware
     attr_accessor :name
     attr_accessor :provider
     attr_accessor :region
+    attr_accessor :networkcidr
 
     # Fields above this line have been ported to the new model
 
-    attr_accessor :networkcidr
     attr_accessor :prisubnetcidr
     # aws provider specific
     attr_accessor :prisubnetid, :networkid

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -29,11 +29,11 @@ module Cloudware
     attr_accessor :name
     attr_accessor :id
     attr_accessor :networkcidr
-    attr_accessor :prvsubnetcidr
+    attr_accessor :prisubnetcidr
     attr_accessor :region
     attr_accessor :provider
     # aws provider specific
-    attr_accessor :prvsubnetid, :networkid
+    attr_accessor :prisubnetid, :networkid
 
     def initialize
       @items = {}
@@ -54,15 +54,15 @@ module Cloudware
 
     def describe
       @describe ||= begin
-                    domain = Struct.new :name, :region, :provider, :networkcidr, :prvsubnetcidr
-                    @describe = domain.new(get_item('domain'), get_item('region'), get_item('provider'), get_item('network_cidr'), get_item('prv_subnet_cidr'))
+                    domain = Struct.new :name, :region, :provider, :networkcidr, :prisubnetcidr
+                    @describe = domain.new(get_item('domain'), get_item('region'), get_item('provider'), get_item('network_cidr'), get_item('pri_subnet_cidr'))
                   end
     end
 
     def create
       load_cloud
       @cloud.create_domain(@name, SecureRandom.uuid, @networkcidr,
-                           @prvsubnetcidr, @region)
+                           @prisubnetcidr, @region)
     end
 
     def _load_domains(provider)

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -47,7 +47,7 @@ module Cloudware
     end
 
     def create
-      cloud.create_domain(@name, SecureRandom.uuid, @networkcidr,
+      cloud.create_domain(name, SecureRandom.uuid, @networkcidr,
                            @prisubnetcidr, @region)
     end
 
@@ -88,13 +88,13 @@ module Cloudware
     def destroy
       raise('Unable to destroy domain with active machines') if has_machines?
       @provider = get_item('provider')
-      cloud.destroy('domain', @name)
+      cloud.destroy('domain', name)
     end
 
     def get_item(item)
       @items[item] = begin
                        log.debug("[#{self.class}] Loading #{item} from API")
-                       list[@name][item.to_sym]
+                       list[name][item.to_sym]
                      end
     end
 
@@ -104,11 +104,11 @@ module Cloudware
     end
 
     def exists?
-      list.include? @name || false
+      list.include? name || false
     end
 
     def valid_name?
-      !@name.match(/\A[a-zA-Z0-9-]*\z/).nil?
+      !name.match(/\A[a-zA-Z0-9-]*\z/).nil?
     end
 
     def valid_provider?

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -32,7 +32,6 @@ module Cloudware
 
     # Fields above this line have been ported to the new model
 
-    attr_accessor :id
     attr_accessor :networkcidr
     attr_accessor :prisubnetcidr
     attr_accessor :region

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -29,12 +29,12 @@ module Cloudware
   class Domain
     attr_accessor :name
     attr_accessor :provider
+    attr_accessor :region
 
     # Fields above this line have been ported to the new model
 
     attr_accessor :networkcidr
     attr_accessor :prisubnetcidr
-    attr_accessor :region
     # aws provider specific
     attr_accessor :prisubnetid, :networkid
 
@@ -85,6 +85,7 @@ module Cloudware
       !name.match(/\A[a-zA-Z0-9-]*\z/).nil?
     end
 
+    # Ported
     def valid_provider?
       %w[aws azure gcp].include? @provider
     end

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -52,16 +52,16 @@ module Cloudware
     end
 
     def _load_domains(provider)
-      case provider
-      when 'aws'
-        cloud = Cloudware::Aws2.new
-      when 'azure'
-        cloud = Cloudware::Azure.new
-      else
-        raise "Provider #{provider} doesn't exist"
-      end
-      log.debug("[#{self.class}] Loaded machines from #{provider}:\n#{cloud.domains}")
-      cloud.domains
+      local_cloud = case provider
+                    when 'aws'
+                      aws
+                    when 'azure'
+                      azure
+                    else
+                      raise "Provider #{provider} doesn't exist"
+                    end
+      log.debug("[#{self.class}] Loaded machines from #{provider}:\n#{local_cloud.domains}")
+      local_cloud.domains
     end
 
     def list

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -104,6 +104,7 @@ module Cloudware
       network_cidr.include?(subnet_cidr)
     end
 
+    # Ported
     def cloud
       case provider
       when 'aws'

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -80,7 +80,7 @@ module Cloudware
     def list
       @list ||= begin
                   @list = {}
-                  @provider.each do |a|
+                  Cloudware.config.providers.each do |a|
                     @list.merge!(_load_domains(a))
                   end
                   log.debug("[#{self.class}] Detected domains:\n#{@list}")

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -80,6 +80,7 @@ module Cloudware
       Cloudware::Domains.list.include? name || false
     end
 
+    # Ported
     def valid_name?
       !name.match(/\A[a-zA-Z0-9-]*\z/).nil?
     end

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -31,10 +31,10 @@ module Cloudware
     attr_accessor :provider
     attr_accessor :region
     attr_accessor :networkcidr
+    attr_accessor :prisubnetcidr
 
     # Fields above this line have been ported to the new model
 
-    attr_accessor :prisubnetcidr
     # aws provider specific
     attr_accessor :prisubnetid, :networkid
 

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -30,11 +30,10 @@ module Cloudware
     attr_accessor :id
     attr_accessor :networkcidr
     attr_accessor :prvsubnetcidr
-    attr_accessor :mgtsubnetcidr
     attr_accessor :region
     attr_accessor :provider
     # aws provider specific
-    attr_accessor :prvsubnetid, :mgtsubnetid, :networkid
+    attr_accessor :prvsubnetid, :networkid
 
     def initialize
       @items = {}
@@ -55,15 +54,15 @@ module Cloudware
 
     def describe
       @describe ||= begin
-                    domain = Struct.new :name, :region, :provider, :networkcidr, :prvsubnetcidr, :mgtsubnetcidr
-                    @describe = domain.new(get_item('domain'), get_item('region'), get_item('provider'), get_item('network_cidr'), get_item('prv_subnet_cidr'), get_item('mgt_subnet_cidr'))
+                    domain = Struct.new :name, :region, :provider, :networkcidr, :prvsubnetcidr
+                    @describe = domain.new(get_item('domain'), get_item('region'), get_item('provider'), get_item('network_cidr'), get_item('prv_subnet_cidr')
                   end
     end
 
     def create
       load_cloud
       @cloud.create_domain(@name, SecureRandom.uuid, @networkcidr,
-                           @prvsubnetcidr, @mgtsubnetcidr, @region)
+                           @prvsubnetcidr, @region)
     end
 
     def _load_domains(provider)

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -28,11 +28,14 @@ require 'domains'
 module Cloudware
   class Domain
     attr_accessor :name
+    attr_accessor :provider
+
+    # Fields above this line have been ported to the new model
+
     attr_accessor :id
     attr_accessor :networkcidr
     attr_accessor :prisubnetcidr
     attr_accessor :region
-    attr_accessor :provider
     # aws provider specific
     attr_accessor :prisubnetid, :networkid
 

--- a/lib/cloudware/domain.rb
+++ b/lib/cloudware/domain.rb
@@ -76,13 +76,7 @@ module Cloudware
     end
 
     def domains_by_region(region)
-      @domains_by_region ||= begin
-                               @domains_by_region = cloud.domains
-                               @domains_by_region.each do |k, v|
-                                 k.delete(k) if v[:region] != region
-                               end
-                               @domains_by_region
-                             end
+      cloud.domains.select { |_k, v| true if v[:region] == region }
     end
 
     def destroy

--- a/lib/cloudware/domains.rb
+++ b/lib/cloudware/domains.rb
@@ -1,0 +1,26 @@
+
+module Cloudware
+  module Domains
+    class << self
+      def list
+        @list ||= begin
+                    @list = {}
+                    Cloudware.config.providers.each do |provider|
+                      @list.merge!(load_domain(provider))
+                    end
+                    @list
+                  end
+      end
+
+      private
+
+      # TODO: Do not use `Domain` to load a cloud to contain a list of
+      # domains. It is just weird
+      def load_domain(provider)
+        d = Domain.new
+        d.provider = provider
+        d.cloud.domains
+      end
+    end
+  end
+end

--- a/lib/cloudware/exceptions.rb
+++ b/lib/cloudware/exceptions.rb
@@ -8,5 +8,5 @@ module Cloudware
 
   # Other errors
   class ConfigError < CloudwareError; end
-  class InvalidInput < CloudwareError; end
+  class InvalidInput < UserError; end
 end

--- a/lib/cloudware/exceptions.rb
+++ b/lib/cloudware/exceptions.rb
@@ -8,4 +8,5 @@ module Cloudware
 
   # Other errors
   class ConfigError < CloudwareError; end
+  class InvalidInput < CloudwareError; end
 end

--- a/lib/cloudware/gcp.rb
+++ b/lib/cloudware/gcp.rb
@@ -25,7 +25,7 @@ require 'google/cloud/resource_manager'
 
 module Cloudware
   class Gcp
-    attr_accessor :name, :networkcidr, :prvsubnetcidr, :mgtsubnetcidr, :region, :infrastructure
+    attr_accessor :name, :networkcidr, :prvsubnetcidr, :region, :infrastructure
 
     def initialize
       @resource_manager = Google::Cloud::ResourceManager.new

--- a/lib/cloudware/gcp.rb
+++ b/lib/cloudware/gcp.rb
@@ -25,7 +25,7 @@ require 'google/cloud/resource_manager'
 
 module Cloudware
   class Gcp
-    attr_accessor :name, :networkcidr, :prvsubnetcidr, :region, :infrastructure
+    attr_accessor :name, :networkcidr, :prisubnetcidr, :region, :infrastructure
 
     def initialize
       @resource_manager = Google::Cloud::ResourceManager.new

--- a/lib/cloudware/machine.rb
+++ b/lib/cloudware/machine.rb
@@ -27,7 +27,7 @@ module Cloudware
   class Machine < Domain
     attr_accessor :name
     attr_accessor :domain
-    attr_accessor :prvip
+    attr_accessor :priip
     attr_accessor :role
     attr_accessor :type
     attr_accessor :flavour
@@ -56,7 +56,7 @@ module Cloudware
         name: @name,
         domain: @domain,
         id: get_item('id'),
-        prvip: get_item('prv_ip'),
+        priip: get_item('pri_ip'),
         role: get_item('role'),
         type: get_item('type'),
         region: get_item('region'),
@@ -66,11 +66,11 @@ module Cloudware
 
     def create
       raise('Invalid machine name') unless validate_name?
-      # raise("IP address #{prvip} is already in use") if ip_in_use? @prvip
+      # raise("IP address #{priip} is already in use") if ip_in_use? @priip
       load_cloud
-      log.info("[#{self.class}] Creating new machine:\nName: #{name}\nDomain: #{domain}\nID: #{id}\nPrv IP: #{prvip}\nType: #{type}\nFlavour: #{flavour}")
+      log.info("[#{self.class}] Creating new machine:\nName: #{name}\nDomain: #{domain}\nID: #{id}\nPri IP: #{priip}\nType: #{type}\nFlavour: #{flavour}")
       @cloud.create_machine(@name, @domain, @d.get_item('id'),
-                            @prvip, @role, render_type, @d.get_item('region'), @flavour)
+                            @priip, @role, render_type, @d.get_item('region'), @flavour)
     end
 
     def destroy
@@ -85,7 +85,7 @@ module Cloudware
       @cloud.create_machine(machine_info[:name],
                             machine_info[:domain],
                             machine_info[:id],
-                            machine_info[:prvip],
+                            machine_info[:priip],
                             machine_info[:role],
                             machine_info[:type],
                             @d.get_item('region'),
@@ -167,7 +167,7 @@ module Cloudware
     def ip_in_use?(ip)
       list.each do |_k, v|
         if v[:domain] == @domain
-          if v[:prv_ip] == ip
+          if v[:pri_ip] == ip
             log.warn("IP address #{ip} is in use by #{v[:name]}")
             return true
             break

--- a/lib/cloudware/machine.rb
+++ b/lib/cloudware/machine.rb
@@ -28,7 +28,6 @@ module Cloudware
     attr_accessor :name
     attr_accessor :domain
     attr_accessor :prvip
-    attr_accessor :mgtip
     attr_accessor :role
     attr_accessor :type
     attr_accessor :flavour
@@ -58,7 +57,6 @@ module Cloudware
         domain: @domain,
         id: get_item('id'),
         prvip: get_item('prv_ip'),
-        mgtip: get_item('mgt_ip'),
         role: get_item('role'),
         type: get_item('type'),
         region: get_item('region'),
@@ -69,11 +67,10 @@ module Cloudware
     def create
       raise('Invalid machine name') unless validate_name?
       # raise("IP address #{prvip} is already in use") if ip_in_use? @prvip
-      # raise("IP address #{mgtip} is already in use") if ip_in_use? @mgtip
       load_cloud
-      log.info("[#{self.class}] Creating new machine:\nName: #{name}\nDomain: #{domain}\nID: #{id}\nPrv IP: #{prvip}\nMgt IP: #{mgtip}\nType: #{type}\nFlavour: #{flavour}")
+      log.info("[#{self.class}] Creating new machine:\nName: #{name}\nDomain: #{domain}\nID: #{id}\nPrv IP: #{prvip}\nType: #{type}\nFlavour: #{flavour}")
       @cloud.create_machine(@name, @domain, @d.get_item('id'),
-                            @prvip, @mgtip, @role, render_type, @d.get_item('region'), @flavour)
+                            @prvip, @role, render_type, @d.get_item('region'), @flavour)
     end
 
     def destroy
@@ -89,7 +86,6 @@ module Cloudware
                             machine_info[:domain],
                             machine_info[:id],
                             machine_info[:prvip],
-                            machine_info[:mgtip],
                             machine_info[:role],
                             machine_info[:type],
                             @d.get_item('region'),
@@ -171,7 +167,7 @@ module Cloudware
     def ip_in_use?(ip)
       list.each do |_k, v|
         if v[:domain] == @domain
-          if v[:mgt_ip] == ip || v[:prv_ip] == ip
+          if v[:prv_ip] == ip
             log.warn("IP address #{ip} is in use by #{v[:name]}")
             return true
             break

--- a/lib/cloudware/models/application.rb
+++ b/lib/cloudware/models/application.rb
@@ -1,0 +1,8 @@
+
+module Cloudware
+  module Models
+    class Application
+      include ActiveModel::Model
+    end
+  end
+end

--- a/lib/cloudware/models/application.rb
+++ b/lib/cloudware/models/application.rb
@@ -3,6 +3,10 @@ module Cloudware
   module Models
     class Application
       include ActiveModel::Model
+
+      def initialize(*_a, **_h)
+        @errors = ActiveModel::Errors.new(self)
+      end
     end
   end
 end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -7,6 +7,17 @@ module Cloudware
       validates_presence_of :name, :region
       validates :name, format: { with: /\A[a-zA-Z0-9-]*\z/ }
       validates :provider, inclusion: { in: Cloudware.config.providers }
+
+      private
+
+      def cloud
+        case provider
+        when 'aws'
+          Aws2.new
+        when 'azure'
+          Azure.new
+        end
+      end
     end
   end
 end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -23,12 +23,16 @@ module Cloudware
       end
 
       def networkcidr_is_ipv4?
+        validate_ipv4?(:networkcidr)
+      end
+
+      def validate_ipv4?(address_name)
         valid = begin
-                  IPAddr.new(networkcidr).ipv4?
+                  IPAddr.new(send(address_name)).ipv4?
                 rescue IPAddr::InvalidAddressError
                   false
                 end
-        errors.add(:networkcidr, 'Is not a IPv4 address') unless valid
+        errors.add(address_name, 'Is not a IPv4 address') unless valid
       end
     end
   end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -2,8 +2,10 @@
 module Cloudware
   module Models
     class Domain < Application
-      attr_accessor :name
+      attr_accessor :name, :provider
+
       validates_presence_of :name
+      validates :provider, inclusion: { in: Cloudware.config.providers }
     end
   end
 end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -3,7 +3,6 @@ module Cloudware
   module Models
     class Domain < Application
       attr_accessor :name
-      validates_presence_of :name
     end
   end
 end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -1,12 +1,15 @@
 
+require 'ipaddr'
+
 module Cloudware
   module Models
     class Domain < Application
-      attr_accessor :name, :provider, :region
+      attr_accessor :name, :provider, :region, :networkcidr
 
       validates_presence_of :name, :region
       validates :name, format: { with: /\A[a-zA-Z0-9-]*\z/ }
       validates :provider, inclusion: { in: Cloudware.config.providers }
+      validate :networkcidr_is_ipv4?
 
       private
 
@@ -17,6 +20,15 @@ module Cloudware
         when 'azure'
           Azure.new
         end
+      end
+
+      def networkcidr_is_ipv4?
+        valid = begin
+                  IPAddr.new(networkcidr).ipv4?
+                rescue IPAddr::InvalidAddressError
+                  false
+                end
+        errors.add(:networkcidr, 'Is not a IPv4 address') unless valid
       end
     end
   end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -9,8 +9,8 @@ module Cloudware
       validates_presence_of :name, :region
       validates :name, format: { with: /\A[a-zA-Z0-9-]*\z/ }
       validates :provider, inclusion: { in: Cloudware.config.providers }
-      validate :networkcidr_is_ipv4?
-      validate :prisubnetcidr_is_ipv4?
+      validate :validate_networkcidr_is_ipv4
+      validate :validate_prisubnetcidr_is_ipv4
 
       private
 
@@ -23,15 +23,15 @@ module Cloudware
         end
       end
 
-      def networkcidr_is_ipv4?
-        validate_ipv4?(:networkcidr)
+      def validate_networkcidr_is_ipv4
+        validate_ipv4(:networkcidr)
       end
 
-      def prisubnetcidr_is_ipv4?
-        validate_ipv4?(:prisubnetcidr)
+      def validate_prisubnetcidr_is_ipv4
+        validate_ipv4(:prisubnetcidr)
       end
 
-      def validate_ipv4?(address_name)
+      def validate_ipv4(address_name)
         valid = begin
                   IPAddr.new(send(address_name)).ipv4?
                 rescue IPAddr::InvalidAddressError

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -2,9 +2,9 @@
 module Cloudware
   module Models
     class Domain < Application
-      attr_accessor :name, :provider
+      attr_accessor :name, :provider, :region
 
-      validates_presence_of :name
+      validates_presence_of :name, :region
       validates :name, format: { with: /\A[a-zA-Z0-9-]*\z/ }
       validates :provider, inclusion: { in: Cloudware.config.providers }
     end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -4,12 +4,13 @@ require 'ipaddr'
 module Cloudware
   module Models
     class Domain < Application
-      attr_accessor :name, :provider, :region, :networkcidr
+      attr_accessor :name, :provider, :region, :networkcidr, :prisubnetcidr
 
       validates_presence_of :name, :region
       validates :name, format: { with: /\A[a-zA-Z0-9-]*\z/ }
       validates :provider, inclusion: { in: Cloudware.config.providers }
       validate :networkcidr_is_ipv4?
+      validate :prisubnetcidr_is_ipv4?
 
       private
 
@@ -24,6 +25,10 @@ module Cloudware
 
       def networkcidr_is_ipv4?
         validate_ipv4?(:networkcidr)
+      end
+
+      def prisubnetcidr_is_ipv4?
+        validate_ipv4?(:prisubnetcidr)
       end
 
       def validate_ipv4?(address_name)

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -5,6 +5,7 @@ module Cloudware
       attr_accessor :name, :provider
 
       validates_presence_of :name
+      validates :name, format: { with: /\A[a-zA-Z0-9-]*\z/ }
       validates :provider, inclusion: { in: Cloudware.config.providers }
     end
   end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -3,6 +3,7 @@ module Cloudware
   module Models
     class Domain < Application
       attr_accessor :name
+      validates_presence_of :name
     end
   end
 end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -1,0 +1,9 @@
+
+module Cloudware
+  module Models
+    class Domain < Application
+      attr_accessor :name
+      validates_presence_of :name
+    end
+  end
+end

--- a/providers/aws/templates/domain.yml
+++ b/providers/aws/templates/domain.yml
@@ -13,9 +13,9 @@ Parameters:
     Type: String
     Description: 'Enter the desired network CIDR'
 
-  prvSubnetCidr:
+  priSubnetCidr:
     Type: String
-    Description: 'Enter the desired prv subnet CIDR'
+    Description: 'Enter the desired pri subnet CIDR'
 
   mgtSubnetCidr:
     Type: String
@@ -42,8 +42,8 @@ Resources:
           Key: 'cloudware_network_cidr'
           Value: !Ref networkCidr
         -
-          Key: 'cloudware_prv_subnet_cidr'
-          Value: !Ref prvSubnetCidr
+          Key: 'cloudware_pri_subnet_cidr'
+          Value: !Ref priSubnetCidr
         -
           Key: 'cloudware_mgt_subnet_cidr'
           Value: !Ref mgtSubnetCidr
@@ -69,10 +69,10 @@ Resources:
       InternetGatewayId: !Ref InternetGateway
       VpcId: !Ref Network
 
-  PrvSubnet:
+  PriSubnet:
     Type: AWS::EC2::Subnet
     Properties:
-      CidrBlock: !Ref prvSubnetCidr
+      CidrBlock: !Ref priSubnetCidr
       VpcId: !Ref Network
       AvailabilityZone: !Select
         - 0
@@ -85,7 +85,7 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
         -
-          Key: !Join ['_', ['cloudware', !Ref cloudwareDomain, 'prv_subnet_id']]
+          Key: !Join ['_', ['cloudware', !Ref cloudwareDomain, 'pri_subnet_id']]
           Value: 'null'
 
   MgtSubnet:
@@ -119,10 +119,10 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
 
-  PrvSubnetRouteTableAssocation:
+  PriSubnetRouteTableAssocation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref PrvSubnet
+      SubnetId: !Ref PriSubnet
       RouteTableId: !Ref RouteTable
 
   MgtSubnetRouteTableAssocation:

--- a/providers/aws/templates/domain0.yml
+++ b/providers/aws/templates/domain0.yml
@@ -30,7 +30,7 @@ Resources:
           Key: 'cloudware_network_cidr'
           Value: '10.78.100.0/24'
         -
-          Key: 'cloudware_prv_subnet_cidr'
+          Key: 'cloudware_pri_subnet_cidr'
           Value: '10.78.100.0/24'
   
   InternetGateway:
@@ -54,7 +54,7 @@ Resources:
       InternetGatewayId: !Ref InternetGateway
       VpcId: !Ref Network
   
-  PrvSubnet:
+  PriSubnet:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock: 10.78.100.0/24
@@ -86,10 +86,10 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
    
-  PrvSubnetRouteTableAssocation:
+  PriSubnetRouteTableAssocation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref PrvSubnet
+      SubnetId: !Ref PriSubnet
       RouteTableId: !Ref RouteTable
 
   RouteInternetGateway:

--- a/providers/aws/templates/domainU.yml
+++ b/providers/aws/templates/domainU.yml
@@ -37,7 +37,7 @@ Resources:
           Key: 'cloudware_network_cidr'
           Value: !Join ['', ['10.100.', !Ref clusterIndex, '.0/24']]
         -
-          Key: 'cloudware_prv_subnet_cidr'
+          Key: 'cloudware_pri_subnet_cidr'
           Value: !Join ['', ['10.100.', !Ref clusterIndex, '.0/24']]
 
   InternetGateway:
@@ -61,7 +61,7 @@ Resources:
       InternetGatewayId: !Ref InternetGateway
       VpcId: !Ref Network
 
-  PrvSubnet:
+  PriSubnet:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock: !Join ['', ['10.100.', !Ref clusterIndex, '.0/24']]
@@ -93,10 +93,10 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
 
-  PrvSubnetRouteTableAssocation:
+  PriSubnetRouteTableAssocation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref PrvSubnet
+      SubnetId: !Ref PriSubnet
       RouteTableId: !Ref RouteTable
 
   RouteInternetGateway:

--- a/providers/aws/templates/machine-gateway.yml
+++ b/providers/aws/templates/machine-gateway.yml
@@ -13,9 +13,9 @@ Parameters:
     Type: String
     Description: 'Enter the VPC/network ID'
 
-  prvSubnetId:
+  priSubnetId:
     Type: String
-    Description: 'Enter the prv subnet ID'
+    Description: 'Enter the pri subnet ID'
 
   keyPairName:
     Default: 'aws_ireland'
@@ -83,19 +83,19 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
 
-  prvInterface:
+  priInterface:
     Type: AWS::EC2::NetworkInterface
     Properties:
-      Description: !Join [' ', [!Ref cloudwareDomain, 'gateway', 'prv network interface']]
+      Description: !Join [' ', [!Ref cloudwareDomain, 'gateway', 'pri network interface']]
       SourceDestCheck: false
       GroupSet:
         - !Ref securityGroupGateway
       PrivateIpAddress: 10.78.100.10
-      SubnetId: !Ref prvSubnetId
+      SubnetId: !Ref priSubnetId
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', [!Ref cloudwareDomain, 'gateway', 'prv']]
+          Value: !Join ['-', [!Ref cloudwareDomain, 'gateway', 'pri']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -115,7 +115,7 @@ Resources:
       KeyName: !Ref keyPairName
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref prvInterface
+          NetworkInterfaceId: !Ref priInterface
           DeviceIndex: 0
       Tags:
         -
@@ -137,7 +137,7 @@ Resources:
           Key: 'cloudware_machine_flavour'
           Value: !Ref vmFlavour
         -
-          Key: 'cloudware_prv_subnet_ip'
+          Key: 'cloudware_pri_subnet_ip'
           Value: 10.78.100.10
 
   publicIp:
@@ -148,5 +148,5 @@ Resources:
   publicIpAssociation:
     Type: AWS::EC2::EIPAssociation
     Properties:
-      NetworkInterfaceId: !Ref prvInterface
+      NetworkInterfaceId: !Ref priInterface
       AllocationId: !GetAtt publicIp.AllocationId

--- a/providers/aws/templates/machine-login.yml
+++ b/providers/aws/templates/machine-login.yml
@@ -13,9 +13,9 @@ Parameters:
     Type: String
     Description: 'Enter the VPC/network ID'
 
-  prvSubnetId:
+  priSubnetId:
     Type: String
-    Description: 'Enter the prv subnet ID'
+    Description: 'Enter the pri subnet ID'
 
   keyPairName:
     Default: 'aws_ireland'
@@ -90,19 +90,19 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
 
-  prvInterface:
+  priInterface:
     Type: AWS::EC2::NetworkInterface
     Properties:
-      Description: !Join [' ', [!Ref cloudwareDomain, 'login', 'prv network interface']]
+      Description: !Join [' ', [!Ref cloudwareDomain, 'login', 'pri network interface']]
       SourceDestCheck: false
       GroupSet:
         - !Ref securityGroupLogin
       PrivateIpAddress: !Join ['', ['10.100.', !Ref clusterIndex, '.10']]
-      SubnetId: !Ref prvSubnetId
+      SubnetId: !Ref priSubnetId
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', [!Ref cloudwareDomain, 'login', 'prv']]
+          Value: !Join ['-', [!Ref cloudwareDomain, 'login', 'pri']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -122,7 +122,7 @@ Resources:
       KeyName: !Ref keyPairName
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref prvInterface
+          NetworkInterfaceId: !Ref priInterface
           DeviceIndex: 0
       Tags:
         -
@@ -144,7 +144,7 @@ Resources:
           Key: 'cloudware_machine_flavour'
           Value: !Ref vmFlavour
         -
-          Key: 'cloudware_prv_subnet_ip'
+          Key: 'cloudware_pri_subnet_ip'
           Value: !Join ['', ['10.100.', !Ref clusterIndex, '.10']]
 
   publicIp:
@@ -155,5 +155,5 @@ Resources:
   publicIpAssociation:
     Type: AWS::EC2::EIPAssociation
     Properties:
-      NetworkInterfaceId: !Ref prvInterface
+      NetworkInterfaceId: !Ref priInterface
       AllocationId: !GetAtt publicIp.AllocationId

--- a/providers/aws/templates/machine-master.yml
+++ b/providers/aws/templates/machine-master.yml
@@ -13,25 +13,25 @@ Parameters:
     Type: String
     Description: 'Enter the VPC/network ID'
 
-  prvSubnetId:
+  priSubnetId:
     Type: String
-    Description: 'Enter the prv subnet ID'
+    Description: 'Enter the pri subnet ID'
 
   mgtSubnetId:
     Type: String
     Description: 'Enter the mgt subnet ID'
 
-  prvIp:
+  priIp:
     Type: String
-    Description: 'Enter the prv subnet IP'
+    Description: 'Enter the pri subnet IP'
 
   mgtIp:
     Type: String
     Description: 'Enter the mgt subnet IP'
 
-  prvSubnetCidr:
+  priSubnetCidr:
     Type: String
-    Description: 'Enter the prv subnet CIDR'
+    Description: 'Enter the pri subnet CIDR'
 
   mgtSubnetCidr:
     Type: String
@@ -104,18 +104,18 @@ Resources:
   securityGroupPri:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupName: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'prv']]
-      GroupDescription: 'Cloudware security group for master machine prv interface'
+      GroupName: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'pri']]
+      GroupDescription: 'Cloudware security group for master machine pri interface'
       VpcId: !Ref networkId
       SecurityGroupIngress:
         -
           IpProtocol: '-1'
-          CidrIp: !Ref prvSubnetCidr
-          Description: 'Allow unrestricted access from the prv subnet'
+          CidrIp: !Ref priSubnetCidr
+          Description: 'Allow unrestricted access from the pri subnet'
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'prv']]
+          Value: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'pri']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -145,20 +145,20 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
 
-  prvInterface:
+  priInterface:
     Type: AWS::EC2::NetworkInterface
     Properties:
-      Description: !Join [' ', [!Ref cloudwareDomain, !Ref vmName, 'prv network interface']]
+      Description: !Join [' ', [!Ref cloudwareDomain, !Ref vmName, 'pri network interface']]
       SourceDestCheck: false
       GroupSet:
         - !Ref securityGroupPri
         - !Ref securityGroupMaster
-      PrivateIpAddress: !Ref prvIp
-      SubnetId: !Ref prvSubnetId
+      PrivateIpAddress: !Ref priIp
+      SubnetId: !Ref priSubnetId
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'prv']]
+          Value: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'pri']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -197,7 +197,7 @@ Resources:
       KeyName: !Ref keyPairName
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref prvInterface
+          NetworkInterfaceId: !Ref priInterface
           DeviceIndex: 0
         -
           NetworkInterfaceId: !Ref mgtInterface
@@ -222,8 +222,8 @@ Resources:
           Key: 'cloudware_machine_flavour'
           Value: !Ref vmFlavour
         -
-          Key: 'cloudware_prv_subnet_ip'
-          Value: !Ref prvIp
+          Key: 'cloudware_pri_subnet_ip'
+          Value: !Ref priIp
         -
           Key: 'cloudware_mgt_subnet_ip'
           Value: !Ref mgtIp
@@ -236,5 +236,5 @@ Resources:
   publicIpAssociation:
     Type: AWS::EC2::EIPAssociation
     Properties:
-      NetworkInterfaceId: !Ref prvInterface
+      NetworkInterfaceId: !Ref priInterface
       AllocationId: !GetAtt publicIp.AllocationId

--- a/providers/aws/templates/machine-master.yml
+++ b/providers/aws/templates/machine-master.yml
@@ -101,7 +101,7 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
 
-  securityGroupPrv:
+  securityGroupPri:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'prv']]
@@ -151,7 +151,7 @@ Resources:
       Description: !Join [' ', [!Ref cloudwareDomain, !Ref vmName, 'prv network interface']]
       SourceDestCheck: false
       GroupSet:
-        - !Ref securityGroupPrv
+        - !Ref securityGroupPri
         - !Ref securityGroupMaster
       PrivateIpAddress: !Ref prvIp
       SubnetId: !Ref prvSubnetId

--- a/providers/aws/templates/machine-slave.yml
+++ b/providers/aws/templates/machine-slave.yml
@@ -13,25 +13,25 @@ Parameters:
     Type: String
     Description: 'Enter the VPC/network ID'
 
-  prvSubnetId:
+  priSubnetId:
     Type: String
-    Description: 'Enter the prv subnet ID'
+    Description: 'Enter the pri subnet ID'
 
   mgtSubnetId:
     Type: String
     Description: 'Enter the mgt subnet ID'
 
-  prvIp:
+  priIp:
     Type: String
-    Description: 'Enter the prv subnet IP'
+    Description: 'Enter the pri subnet IP'
 
   mgtIp:
     Type: String
     Description: 'Enter the mgt subnet IP'
 
-  prvSubnetCidr:
+  priSubnetCidr:
     Type: String
-    Description: 'Enter the prv subnet CIDR'
+    Description: 'Enter the pri subnet CIDR'
 
   mgtSubnetCidr:
     Type: String
@@ -98,18 +98,18 @@ Resources:
   securityGroupPri:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupName: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'prv']]
-      GroupDescription: 'Cloudware security group for slave machine prv interface'
+      GroupName: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'pri']]
+      GroupDescription: 'Cloudware security group for slave machine pri interface'
       VpcId: !Ref networkId
       SecurityGroupIngress:
         -
           IpProtocol: '-1'
-          CidrIp: !Ref prvSubnetCidr
-          Description: 'Allow unrestricted access from the prv subnet'
+          CidrIp: !Ref priSubnetCidr
+          Description: 'Allow unrestricted access from the pri subnet'
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'prv']]
+          Value: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'pri']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -139,19 +139,19 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
 
-  prvInterface:
+  priInterface:
     Type: AWS::EC2::NetworkInterface
     Properties:
-      Description: !Join [' ', [!Ref cloudwareDomain, !Ref vmName, 'prv network interface']]
+      Description: !Join [' ', [!Ref cloudwareDomain, !Ref vmName, 'pri network interface']]
       GroupSet:
         - !Ref securityGroupPri
         - !Ref securityGroupSlave
-      PrivateIpAddress: !Ref prvIp
-      SubnetId: !Ref prvSubnetId
+      PrivateIpAddress: !Ref priIp
+      SubnetId: !Ref priSubnetId
       Tags:
         -
           Key: 'Name'
-          Value: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'prv']]
+          Value: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'pri']]
         -
           Key: 'cloudware_id'
           Value: !Ref cloudwareId
@@ -190,7 +190,7 @@ Resources:
       KeyName: !Ref keyPairName
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref prvInterface
+          NetworkInterfaceId: !Ref priInterface
           DeviceIndex: 0
         -
           NetworkInterfaceId: !Ref mgtInterface
@@ -215,8 +215,8 @@ Resources:
           Key: 'cloudware_machine_flavour'
           Value: !Ref vmFlavour
         -
-          Key: 'cloudware_prv_subnet_ip'
-          Value: !Ref prvIp
+          Key: 'cloudware_pri_subnet_ip'
+          Value: !Ref priIp
         -
           Key: 'cloudware_mgt_subnet_ip'
           Value: !Ref mgtIp

--- a/providers/aws/templates/machine-slave.yml
+++ b/providers/aws/templates/machine-slave.yml
@@ -95,7 +95,7 @@ Resources:
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
 
-  securityGroupPrv:
+  securityGroupPri:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: !Join ['-', [!Ref cloudwareDomain, !Ref vmName, 'prv']]
@@ -144,7 +144,7 @@ Resources:
     Properties:
       Description: !Join [' ', [!Ref cloudwareDomain, !Ref vmName, 'prv network interface']]
       GroupSet:
-        - !Ref securityGroupPrv
+        - !Ref securityGroupPri
         - !Ref securityGroupSlave
       PrivateIpAddress: !Ref prvIp
       SubnetId: !Ref prvSubnetId

--- a/providers/azure/templates/domain.json
+++ b/providers/azure/templates/domain.json
@@ -9,11 +9,11 @@
         "description": "Choose the desired network range"
       }
     },
-    "prvSubnetCIDR": {
+    "priSubnetCIDR": {
       "type": "string",
       "defaultValue": "10.0.1.0/24",
       "metadata": {
-        "description": "Choose the desired prv subnet range"
+        "description": "Choose the desired pri subnet range"
       }
     },
     "mgtSubnetCIDR": {
@@ -46,7 +46,7 @@
         "cloudware_domain": "[parameters('cloudwareDomain')]",
         "cloudware_domain_region": "[resourceGroup().location]",
         "cloudware_network_cidr": "[parameters('networkCIDR')]",
-        "cloudware_prv_subnet_cidr": "[parameters('prvSubnetCIDR')]",
+        "cloudware_pri_subnet_cidr": "[parameters('priSubnetCIDR')]",
         "cloudware_mgt_subnet_cidr": "[parameters('mgtSubnetCIDR')]",
         "cloudware_resource_type": "domain"
       },
@@ -59,9 +59,9 @@
         },
         "subnets": [
           {
-            "name": "prv",
+            "name": "pri",
             "properties": {
-              "addressPrefix": "[parameters('prvSubnetCIDR')]"
+              "addressPrefix": "[parameters('priSubnetCIDR')]"
             }
           },
           {

--- a/providers/azure/templates/machine-master.json
+++ b/providers/azure/templates/machine-master.json
@@ -32,10 +32,10 @@
 				"description": "Choose the VM flavour"
 			}
 		},
-		"prvSubnetIp": {
+		"priSubnetIp": {
 			"type": "string",
 			"metadata": {
-				"description": "Enter the desired prv subnet IP address"
+				"description": "Enter the desired pri subnet IP address"
 			}
 		},
 		"mgtSubnetIp": {
@@ -48,7 +48,7 @@
 	"variables": {
 		"adminUsername": "alces",
 		"adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/0R5EvmSrySy2I+8Cx6eOX7cVuYFXx5D0O1x0+OmAZ0Qaj9d7E0Nj4ZcWxdCT03uFl1Ka4tInDlQmMyy0V1/AftpHxBEnB17Pk/lJnDW1YstmAqD0GlFa1CrxUdtHd+jB3LJmdoHsV6fRGpMOgFd+u/4Wces7KAqYFmL5uPG1UTCMgokQ2qboQgEVspXotMvni1iil3kEjyH/eW64Laxmn2Vxls9feZ1o95mPQhJPJcN7MMo1h+jkxyat3bawtpqyV7fXYU0+BO2JHpu/VIEDHtxhlk7RhI0U06XbJu6ZCCUrEX8idIhw4hueQpKwVYplTXssa9JqNlcjouqLj5kd cloudware@alces-software.com",
-		"prvInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'prv')]",
+		"priInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'pri')]",
 		"mgtInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'mgt')]",
 		"azureConfig": {
 			"imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
@@ -98,7 +98,7 @@
 		},
 		{
 			"type": "Microsoft.Network/networkInterfaces",
-			"name": "[variables('prvInterfaceName')]",
+			"name": "[variables('priInterfaceName')]",
 			"apiVersion": "2017-03-01",
 			"tags": {
 				"cloudware_domain": "[parameters('cloudwareDomain')]",
@@ -107,15 +107,15 @@
 			"location": "[resourceGroup().location]",
 			"properties": {
 				"ipConfigurations": [{
-					"name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-prv')]",
+					"name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-pri')]",
 					"properties": {
 						"privateIPAllocationMethod": "Static",
-						"privateIPAddress": "[parameters('prvSubnetIp')]",
+						"privateIPAddress": "[parameters('priSubnetIp')]",
 						"publicIPAddress": {
 							"id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
 						},
 						"subnet": {
-							"id": "[resourceId(parameters('cloudwareDomain'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'prv')]"
+							"id": "[resourceId(parameters('cloudwareDomain'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
 						}
 					}
 				}],
@@ -161,7 +161,7 @@
 				"cloudware_machine_type": "[parameters('vmType')]",
 				"cloudware_machine_flavour": "[parameters('vmFlavour')]",
 				"cloudware_resource_type": "machine",
-				"cloudware_prv_ip": "[parameters('prvSubnetIp')]",
+				"cloudware_pri_ip": "[parameters('priSubnetIp')]",
 				"cloudware_mgt_ip": "[parameters('mgtSubnetIp')]"
 			},
 			"location": "[resourceGroup().location]",
@@ -184,7 +184,7 @@
 					}
 				},
 				"osProfile": {
-					"computerName": "[concat(parameters('vmName'), '.prv.', parameters('cloudwareDomain'), '.alces.network')]",
+					"computerName": "[concat(parameters('vmName'), '.pri.', parameters('cloudwareDomain'), '.alces.network')]",
 					"adminUsername": "[variables('adminUsername')]",
 					"linuxConfiguration": {
 						"disablePasswordAuthentication": true,
@@ -198,7 +198,7 @@
 				},
 				"networkProfile": {
 					"networkInterfaces": [{
-							"id": "[resourceId('Microsoft.Network/networkInterfaces', variables('prvInterfaceName'))]",
+							"id": "[resourceId('Microsoft.Network/networkInterfaces', variables('priInterfaceName'))]",
 							"properties": {
 								"primary": true
 							}
@@ -213,7 +213,7 @@
 				}
 			},
 			"dependsOn": [
-				"[resourceId('Microsoft.Network/networkInterfaces', variables('prvInterfaceName'))]",
+				"[resourceId('Microsoft.Network/networkInterfaces', variables('priInterfaceName'))]",
 				"[resourceId('Microsoft.Network/networkInterfaces', variables('mgtInterfaceName'))]"
 			]
 		}

--- a/providers/azure/templates/machine-slave.json
+++ b/providers/azure/templates/machine-slave.json
@@ -32,10 +32,10 @@
 				"description": "Choose the VM flavour"
 			}
 		},
-		"prvSubnetIp": {
+		"priSubnetIp": {
 			"type": "string",
 			"metadata": {
-				"description": "Enter the desired prv subnet IP address"
+				"description": "Enter the desired pri subnet IP address"
 			}
 		},
 		"mgtSubnetIp": {
@@ -48,7 +48,7 @@
 	"variables": {
 		"adminUsername": "alces",
 		"adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/0R5EvmSrySy2I+8Cx6eOX7cVuYFXx5D0O1x0+OmAZ0Qaj9d7E0Nj4ZcWxdCT03uFl1Ka4tInDlQmMyy0V1/AftpHxBEnB17Pk/lJnDW1YstmAqD0GlFa1CrxUdtHd+jB3LJmdoHsV6fRGpMOgFd+u/4Wces7KAqYFmL5uPG1UTCMgokQ2qboQgEVspXotMvni1iil3kEjyH/eW64Laxmn2Vxls9feZ1o95mPQhJPJcN7MMo1h+jkxyat3bawtpqyV7fXYU0+BO2JHpu/VIEDHtxhlk7RhI0U06XbJu6ZCCUrEX8idIhw4hueQpKwVYplTXssa9JqNlcjouqLj5kd cloudware@alces-software.com",
-		"prvInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'prv')]",
+		"priInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'pri')]",
 		"mgtInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'mgt')]",
 		"azureConfig": {
 			"imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
@@ -81,7 +81,7 @@
 		},
 		{
 			"type": "Microsoft.Network/networkInterfaces",
-			"name": "[variables('prvInterfaceName')]",
+			"name": "[variables('priInterfaceName')]",
 			"apiVersion": "2017-03-01",
 			"tags": {
 				"cloudware_domain": "[parameters('cloudwareDomain')]",
@@ -90,12 +90,12 @@
 			"location": "[resourceGroup().location]",
 			"properties": {
 				"ipConfigurations": [{
-					"name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-prv')]",
+					"name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-pri')]",
 					"properties": {
 						"privateIPAllocationMethod": "Static",
-						"privateIPAddress": "[parameters('prvSubnetIp')]",
+						"privateIPAddress": "[parameters('priSubnetIp')]",
 						"subnet": {
-							"id": "[resourceId(parameters('cloudwareDomain'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'prv')]"
+							"id": "[resourceId(parameters('cloudwareDomain'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
 						}
 					}
 				}],
@@ -141,7 +141,7 @@
 				"cloudware_machine_type": "[parameters('vmType')]",
 				"cloudware_machine_flavour": "[parameters('vmFlavour')]",
 				"cloudware_resource_type": "machine",
-				"cloudware_prv_ip": "[parameters('prvSubnetIp')]",
+				"cloudware_pri_ip": "[parameters('priSubnetIp')]",
 				"cloudware_mgt_ip": "[parameters('mgtSubnetIp')]"
 			},
 			"location": "[resourceGroup().location]",
@@ -161,7 +161,7 @@
 					}
 				},
 				"osProfile": {
-					"computerName": "[concat(parameters('vmName'), '.prv.', parameters('cloudwareDomain'), '.alces.network')]",
+					"computerName": "[concat(parameters('vmName'), '.pri.', parameters('cloudwareDomain'), '.alces.network')]",
 					"adminUsername": "[variables('adminUsername')]",
 					"linuxConfiguration": {
 						"disablePasswordAuthentication": true,
@@ -175,7 +175,7 @@
 				},
 				"networkProfile": {
 					"networkInterfaces": [{
-							"id": "[resourceId('Microsoft.Network/networkInterfaces', variables('prvInterfaceName'))]",
+							"id": "[resourceId('Microsoft.Network/networkInterfaces', variables('priInterfaceName'))]",
 							"properties": {
 								"primary": true
 							}
@@ -190,7 +190,7 @@
 				}
 			},
 			"dependsOn": [
-				"[resourceId('Microsoft.Network/networkInterfaces', variables('prvInterfaceName'))]",
+				"[resourceId('Microsoft.Network/networkInterfaces', variables('priInterfaceName'))]",
 				"[resourceId('Microsoft.Network/networkInterfaces', variables('mgtInterfaceName'))]"
 			]
 		}

--- a/spec/cloudware/models/domain_spec.rb
+++ b/spec/cloudware/models/domain_spec.rb
@@ -39,5 +39,13 @@ RSpec.describe Cloudware::Models::Domain do
 
   describe '#prisubnetcidr' do
     include_examples 'valid IPv4', :prisubnetcidr
+
+    it 'must be contained within the networkcidr' do
+      ip_ranges = {
+        networkcidr: '10.0.0.0/16',
+        prisubnetcidr: '11.0.1.0/24'
+      }
+      expect(build(:domain, **ip_ranges)).not_to be_valid
+    end
   end
 end

--- a/spec/cloudware/models/domain_spec.rb
+++ b/spec/cloudware/models/domain_spec.rb
@@ -26,9 +26,14 @@ RSpec.describe Cloudware::Models::Domain do
     end
   end
 
-  describe '#networkcidr' do
+  shared_examples 'valid IPv4' do |address_name|
     it 'must be an IPv4 address' do
-      expect(build(:domain, networkcidr: '10.0.0.257')).not_to be_valid
+      domain = build(:domain, address_name => '10.0.0.257/16')
+      expect(domain).not_to be_valid
     end
+  end
+
+  describe '#networkcidr' do
+    include_examples 'valid IPv4', :networkcidr
   end
 end

--- a/spec/cloudware/models/domain_spec.rb
+++ b/spec/cloudware/models/domain_spec.rb
@@ -1,0 +1,6 @@
+
+RSpec.describe Cloudware::Models::Domain do
+  it 'can build a valid domain object' do
+    expect(build(:domain)).to be_valid
+  end
+end

--- a/spec/cloudware/models/domain_spec.rb
+++ b/spec/cloudware/models/domain_spec.rb
@@ -4,7 +4,15 @@ RSpec.describe Cloudware::Models::Domain do
     expect(build(:domain)).to be_valid
   end
 
-  it 'requires the name field' do
-    expect(build(:domain, name: nil)).not_to be_valid
+  describe '#name' do
+    it 'can not be nil' do
+      expect(build(:domain, name: nil)).not_to be_valid
+    end
+  end
+
+  describe '#provider' do
+    it 'must be a supported provider' do
+      expect(build(:domain, provider: 'missing')).not_to be_valid
+    end
   end
 end

--- a/spec/cloudware/models/domain_spec.rb
+++ b/spec/cloudware/models/domain_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Cloudware::Models::Domain do
     it 'can not be nil' do
       expect(build(:domain, name: nil)).not_to be_valid
     end
+
+    it 'errors if it contains special characters' do
+      expect(build(:domain, name: '!!')).not_to be_valid
+    end
   end
 
   describe '#provider' do

--- a/spec/cloudware/models/domain_spec.rb
+++ b/spec/cloudware/models/domain_spec.rb
@@ -3,4 +3,8 @@ RSpec.describe Cloudware::Models::Domain do
   it 'can build a valid domain object' do
     expect(build(:domain)).to be_valid
   end
+
+  it 'requires the name field' do
+    expect(build(:domain, name: nil)).not_to be_valid
+  end
 end

--- a/spec/cloudware/models/domain_spec.rb
+++ b/spec/cloudware/models/domain_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe Cloudware::Models::Domain do
       expect(build(:domain, provider: 'missing')).not_to be_valid
     end
   end
+
+  describe '#region' do
+    it 'can not be nil' do
+      expect(build(:domain, region: nil)).not_to be_valid
+    end
+  end
 end

--- a/spec/cloudware/models/domain_spec.rb
+++ b/spec/cloudware/models/domain_spec.rb
@@ -36,4 +36,8 @@ RSpec.describe Cloudware::Models::Domain do
   describe '#networkcidr' do
     include_examples 'valid IPv4', :networkcidr
   end
+
+  describe '#prisubnetcidr' do
+    include_examples 'valid IPv4', :prisubnetcidr
+  end
 end

--- a/spec/cloudware/models/domain_spec.rb
+++ b/spec/cloudware/models/domain_spec.rb
@@ -25,4 +25,10 @@ RSpec.describe Cloudware::Models::Domain do
       expect(build(:domain, region: nil)).not_to be_valid
     end
   end
+
+  describe '#networkcidr' do
+    it 'must be an IPv4 address' do
+      expect(build(:domain, networkcidr: '10.0.0.257')).not_to be_valid
+    end
+  end
 end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -4,7 +4,7 @@ require 'ostruct'
 module Cloudware
   module Commands
     class TestCommand < Command
-    def run; end
+      def run; end
     end
   end
 end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Cloudware::Command do
       end
     end
 
-    context 'woth the options missing' do
+    context 'with the options missing' do
       it 'raise an error' do
         expect do
           subject.run!

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -1,0 +1,20 @@
+
+require 'ostruct'
+
+module Cloudware
+  module Commands
+    class TestCommand < Command
+    def run; end
+    end
+  end
+end
+
+RSpec.describe Cloudware::Command do
+  subject { Cloudware::Commands::TestCommand.new(args, options) }
+  let(:args) { [] }
+  let(:options) { OpenStruct.new() }
+
+  it 'does nothing with blank arguments' do
+    expect { subject.run! }.not_to raise_error
+  end
+end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -17,4 +17,23 @@ RSpec.describe Cloudware::Command do
   it 'does nothing with blank arguments' do
     expect { subject.run! }.not_to raise_error
   end
+
+  describe '#required_options' do
+    let(:required) { [:required_option1, :required_option2] }
+    before do
+      allow(subject).to receive(:required_options).and_return(required)
+    end
+
+    context 'with the required options' do
+      let(:options) do
+        required.each_with_object(OpenStruct.new) do |opt, accum|
+          accum[opt] = 'filled'
+        end
+      end
+
+      it 'does not error' do
+        expect { subject.run! }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe Cloudware::Command do
         expect { subject.run! }.not_to raise_error
       end
     end
+
+    context 'woth the options missing' do
+      it 'raise an error' do
+        expect do
+          subject.run!
+        end.to raise_error(Cloudware::InvalidInput, /#{required.first}/)
+      end
+    end
   end
 end

--- a/spec/domain_spec.rb
+++ b/spec/domain_spec.rb
@@ -6,7 +6,6 @@ require 'cloudware/aws'
 require 'cloudware/config'
 require 'cloudware/log'
 require 'cloudware'
-require 'rspec/wait'
 
 describe Cloudware::Domain do
   context 'with provider azure' do

--- a/spec/domain_spec.rb
+++ b/spec/domain_spec.rb
@@ -15,7 +15,7 @@ describe Cloudware::Domain do
       @provider = 'azure'
       @region = 'uksouth'
       @networkcidr = '10.0.0.0/16'
-      @prvsubnetcidr = '10.0.1.0/24'
+      @prisubnetcidr = '10.0.1.0/24'
       @domain = described_class.new
       @domain.name = @name
       @domain.provider = @provider
@@ -43,19 +43,19 @@ describe Cloudware::Domain do
       expect(@domain.valid_cidr?(@networkcidr)).to be(true)
     end
 
-    it 'returns the correct prv subnet cidr' do
-      @domain.prvsubnetcidr = @prvsubnetcidr
-      expect(@domain.prvsubnetcidr).to eq(@prvsubnetcidr)
+    it 'returns the correct pri subnet cidr' do
+      @domain.prisubnetcidr = @prisubnetcidr
+      expect(@domain.prisubnetcidr).to eq(@prisubnetcidr)
     end
 
-    it 'validates the prv subnet cidrs' do
-      expect(@domain.is_valid_subnet_cidr?(@networkcidr, @prvsubnetcidr)).to be(true)
+    it 'validates the pri subnet cidrs' do
+      expect(@domain.is_valid_subnet_cidr?(@networkcidr, @prisubnetcidr)).to be(true)
     end
 
     xit 'creates a new domain' do
       @domain.region = 'uksouth'
       @domain.networkcidr = @networkcidr
-      @domain.prvsubnetcidr = @prvsubnetcidr
+      @domain.prisubnetcidr = @prisubnetcidr
       @domain.create
       wait_for(@domain.exists?).to be(true)
     end
@@ -70,7 +70,7 @@ describe Cloudware::Domain do
       expect(domain).to have_attributes(region: @region)
       expect(domain).to have_attributes(provider: @provider)
       expect(domain).to have_attributes(networkcidr: @networkcidr)
-      expect(domain).to have_attributes(prvsubnetcidr: @prvsubnetcidr)
+      expect(domain).to have_attributes(prisubnetcidr: @prisubnetcidr)
     end
 
     xit 'destroys the domain' do
@@ -85,7 +85,7 @@ describe Cloudware::Domain do
       @provider = 'aws'
       @region = 'eu-west-1'
       @networkcidr = '10.0.0.0/16'
-      @prvsubnetcidr = '10.0.1.0/24'
+      @prisubnetcidr = '10.0.1.0/24'
       @domain = described_class.new
       @domain.name = @name
       @domain.provider = @provider
@@ -113,19 +113,19 @@ describe Cloudware::Domain do
       expect(@domain.valid_cidr?(@networkcidr)).to be(true)
     end
 
-    it 'returns the correct prv subnet cidr' do
-      @domain.prvsubnetcidr = @prvsubnetcidr
-      expect(@domain.prvsubnetcidr).to eq(@prvsubnetcidr)
+    it 'returns the correct pri subnet cidr' do
+      @domain.prisubnetcidr = @prisubnetcidr
+      expect(@domain.prisubnetcidr).to eq(@prisubnetcidr)
     end
 
-    it 'validates the prv subnet cidrs' do
-      expect(@domain.is_valid_subnet_cidr?(@networkcidr, @prvsubnetcidr)).to be(true)
+    it 'validates the pri subnet cidrs' do
+      expect(@domain.is_valid_subnet_cidr?(@networkcidr, @prisubnetcidr)).to be(true)
     end
 
     xit 'creates a new domain' do
       @domain.region = @region
       @domain.networkcidr = @networkcidr
-      @domain.prvsubnetcidr = @prvsubnetcidr
+      @domain.prisubnetcidr = @prisubnetcidr
       @domain.create
       wait_for(@domain.exists?).to be(true)
     end
@@ -140,7 +140,7 @@ describe Cloudware::Domain do
       expect(domain).to have_attributes(region: @region)
       expect(domain).to have_attributes(provider: @provider)
       expect(domain).to have_attributes(networkcidr: @networkcidr)
-      expect(domain).to have_attributes(prvsubnetcidr: @prvsubnetcidr)
+      expect(domain).to have_attributes(prisubnetcidr: @prisubnetcidr)
     end
 
     xit 'destroys the domain' do

--- a/spec/domain_spec.rb
+++ b/spec/domain_spec.rb
@@ -16,7 +16,6 @@ describe Cloudware::Domain do
       @region = 'uksouth'
       @networkcidr = '10.0.0.0/16'
       @prvsubnetcidr = '10.0.1.0/24'
-      @mgtsubnetcidr = '10.0.2.0/24'
       @domain = described_class.new
       @domain.name = @name
       @domain.provider = @provider
@@ -49,21 +48,14 @@ describe Cloudware::Domain do
       expect(@domain.prvsubnetcidr).to eq(@prvsubnetcidr)
     end
 
-    it 'validates the prv/mgt subnet cidrs' do
+    it 'validates the prv subnet cidrs' do
       expect(@domain.is_valid_subnet_cidr?(@networkcidr, @prvsubnetcidr)).to be(true)
-      expect(@domain.is_valid_subnet_cidr?(@networkcidr, @mgtsubnetcidr)).to be(true)
-    end
-
-    it 'returns the correct mgt subnet cidr' do
-      @domain.mgtsubnetcidr = @mgtsubnetcidr
-      expect(@domain.mgtsubnetcidr).to eq(@mgtsubnetcidr)
     end
 
     xit 'creates a new domain' do
       @domain.region = 'uksouth'
       @domain.networkcidr = @networkcidr
       @domain.prvsubnetcidr = @prvsubnetcidr
-      @domain.mgtsubnetcidr = @mgtsubnetcidr
       @domain.create
       wait_for(@domain.exists?).to be(true)
     end
@@ -79,7 +71,6 @@ describe Cloudware::Domain do
       expect(domain).to have_attributes(provider: @provider)
       expect(domain).to have_attributes(networkcidr: @networkcidr)
       expect(domain).to have_attributes(prvsubnetcidr: @prvsubnetcidr)
-      expect(domain).to have_attributes(mgtsubnetcidr: @mgtsubnetcidr)
     end
 
     xit 'destroys the domain' do
@@ -95,7 +86,6 @@ describe Cloudware::Domain do
       @region = 'eu-west-1'
       @networkcidr = '10.0.0.0/16'
       @prvsubnetcidr = '10.0.1.0/24'
-      @mgtsubnetcidr = '10.0.2.0/24'
       @domain = described_class.new
       @domain.name = @name
       @domain.provider = @provider
@@ -128,21 +118,14 @@ describe Cloudware::Domain do
       expect(@domain.prvsubnetcidr).to eq(@prvsubnetcidr)
     end
 
-    it 'validates the prv/mgt subnet cidrs' do
+    it 'validates the prv subnet cidrs' do
       expect(@domain.is_valid_subnet_cidr?(@networkcidr, @prvsubnetcidr)).to be(true)
-      expect(@domain.is_valid_subnet_cidr?(@networkcidr, @mgtsubnetcidr)).to be(true)
-    end
-
-    it 'returns the correct mgt subnet cidr' do
-      @domain.mgtsubnetcidr = @mgtsubnetcidr
-      expect(@domain.mgtsubnetcidr).to eq(@mgtsubnetcidr)
     end
 
     xit 'creates a new domain' do
       @domain.region = @region
       @domain.networkcidr = @networkcidr
       @domain.prvsubnetcidr = @prvsubnetcidr
-      @domain.mgtsubnetcidr = @mgtsubnetcidr
       @domain.create
       wait_for(@domain.exists?).to be(true)
     end
@@ -158,7 +141,6 @@ describe Cloudware::Domain do
       expect(domain).to have_attributes(provider: @provider)
       expect(domain).to have_attributes(networkcidr: @networkcidr)
       expect(domain).to have_attributes(prvsubnetcidr: @prvsubnetcidr)
-      expect(domain).to have_attributes(mgtsubnetcidr: @mgtsubnetcidr)
     end
 
     xit 'destroys the domain' do

--- a/spec/domain_spec.rb
+++ b/spec/domain_spec.rb
@@ -59,7 +59,7 @@ describe Cloudware::Domain do
       expect(@domain.mgtsubnetcidr).to eq(@mgtsubnetcidr)
     end
 
-    it 'creates a new domain' do
+    xit 'creates a new domain' do
       @domain.region = 'uksouth'
       @domain.networkcidr = @networkcidr
       @domain.prvsubnetcidr = @prvsubnetcidr
@@ -68,11 +68,11 @@ describe Cloudware::Domain do
       wait_for(@domain.exists?).to be(true)
     end
 
-    it 'returns a list of domains as a hash' do
+    xit 'returns a list of domains as a hash' do
       expect(@domain.list).to be_a(Hash)
     end
 
-    it 'returns the correct domain information from API' do
+    xit 'returns the correct domain information from API' do
       domain = @domain.describe
       expect(domain).to have_attributes(name: @name)
       expect(domain).to have_attributes(region: @region)
@@ -82,7 +82,7 @@ describe Cloudware::Domain do
       expect(domain).to have_attributes(mgtsubnetcidr: @mgtsubnetcidr)
     end
 
-    it 'destroys the domain' do
+    xit 'destroys the domain' do
       @domain.destroy
       wait_for(@domain.exists?).to be(false)
     end
@@ -138,7 +138,7 @@ describe Cloudware::Domain do
       expect(@domain.mgtsubnetcidr).to eq(@mgtsubnetcidr)
     end
 
-    it 'creates a new domain' do
+    xit 'creates a new domain' do
       @domain.region = @region
       @domain.networkcidr = @networkcidr
       @domain.prvsubnetcidr = @prvsubnetcidr
@@ -147,11 +147,11 @@ describe Cloudware::Domain do
       wait_for(@domain.exists?).to be(true)
     end
 
-    it 'returns a list of domains as a hash' do
+    xit 'returns a list of domains as a hash' do
       expect(@domain.list).to be_a(Hash)
     end
 
-    it 'returns the correct domain information from API' do
+    xit 'returns the correct domain information from API' do
       domain = @domain.describe
       expect(domain).to have_attributes(name: @name)
       expect(domain).to have_attributes(region: @region)
@@ -161,7 +161,7 @@ describe Cloudware::Domain do
       expect(domain).to have_attributes(mgtsubnetcidr: @mgtsubnetcidr)
     end
 
-    it 'destroys the domain' do
+    xit 'destroys the domain' do
       @domain.destroy
       wait_for(@domain.exists?).to be(false)
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,8 @@
+
+FactoryBot.define do
+  models = Cloudware::Models
+
+  factory :domain, class: models::Domain do
+    name 'test-domain-name'
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
   models = Cloudware::Models
 
   factory :domain, class: models::Domain do
-    name 'test-domain-name'
+    name 'Test-Domain-Name-1'
     provider 'aws'
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
 
   factory :domain, class: models::Domain do
     name 'test-domain-name'
+    provider 'aws'
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     name 'Test-Domain-Name-1'
     provider 'aws'
     region 'eu-west-1'
+    networkcidr '10.0.0.0/16'
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
   factory :domain, class: models::Domain do
     name 'Test-Domain-Name-1'
     provider 'aws'
+    region 'eu-west-1'
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     provider 'aws'
     region 'eu-west-1'
     networkcidr '10.0.0.0/16'
+    prisubnetcidr '10.0.1.0/24'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,15 @@
 
 require 'rspec/wait'
 require File.join(File.dirname(__FILE__), '../lib/cloudware')
+Bundler.setup(:development)
+require 'factory_bot'
 
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
+
   config.wait_timeout = 120
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
The `Domain` class over complicates how to create/ view a domain. Fundamentally, it needs to run some validation to ensure a domain is valid and then `create` it. Apart from this, it also needs to be able to `destroy` domains (plus some assorted other functions).

The majority of the above requirements can be achieved by using the `ActiveModel` class from `rails`. As `Cloudware` does not have a `db` backing, `ActiveModel` is used over `ActiveRecord`.

Fundamentally the new `Model::Domain` achieves the same validation with the same inputs as the original `Domain` class. However it is easier to initialise (using the `build` method), validate (`valid?`), and test (using `FactoryBot`).

As this is `ActiveModel`, the `create` method has not been defined (as `ActiveRecord` would create the `db` entry). However a latter PR will implement the `create` as replacement to the existing `Cloudware::Domain.new.create` method.