### PR TITLE
Allow the domain template to be set from the CLI

### DIFF
--- a/lib/cloudware/machine.rb
+++ b/lib/cloudware/machine.rb
@@ -68,7 +68,6 @@ module Cloudware
       raise('Invalid machine name') unless validate_name?
       # raise("IP address #{priip} is already in use") if ip_in_use? @priip
       load_cloud
-      log.info("[#{self.class}] Creating new machine:\nName: #{name}\nDomain: #{domain}\nID: #{id}\nPri IP: #{priip}\nType: #{type}\nFlavour: #{flavour}")
       @cloud.create_machine(@name, @domain, @d.get_item('id'),
                             @priip, @role, render_type, @d.get_item('region'), @flavour)
     end

--- a/providers/aws/templates/domainU.yml
+++ b/providers/aws/templates/domainU.yml
@@ -87,6 +87,9 @@ Resources:
         -
           Key: 'cloudware_domain'
           Value: !Ref cloudwareDomain
+        -
+          Key: !Join ['_', ['cloudware', !Ref cloudwareDomain, 'pri_subnet_id']]
+          Value: 'null'
 
   RouteTable:
     Type: AWS::EC2::RouteTable

--- a/providers/aws/templates/machine-login.yml
+++ b/providers/aws/templates/machine-login.yml
@@ -13,6 +13,14 @@ Parameters:
     Type: String
     Description: 'Enter the VPC/network ID'
 
+  priIp:
+    Type: String
+    Description: 'Enter the pri subnet IP'
+
+  priSubnetCidr:
+    Type: String
+    Description: 'Enter the pri subnet CIDR'
+
   priSubnetId:
     Type: String
     Description: 'Enter the pri subnet ID'
@@ -33,6 +41,10 @@ Parameters:
   vmFlavour:
     Type: String
     Description: 'Enter the VM flavour'
+
+  vmName:
+    Type: String
+    Description: 'Enter the desired instance name'
 
   clusterIndex: 
     Type: Number

--- a/support/flightconnector/domain0-gateway.sh
+++ b/support/flightconnector/domain0-gateway.sh
@@ -205,7 +205,7 @@ firewall-cmd --add-port 2005/tcp --zone external --permanent
 
 firewall-cmd --set-target=ACCEPT --zone $CLUSTER --permanent
 
-sed '/^ZONE=/{h;s/=.*/=external/};${x;/^$/{s//ZONE=external/;H};x}' /etc/sysconfig/network-scripts/ifcfg-eth0 -i
+sed '/^ZONE=/{h;s/=.*/=external/};\${x;/^$/{s//ZONE=external/;H};x}' /etc/sysconfig/network-scripts/ifcfg-eth0 -i
 
 echo "Please reboot"
 EOF


### PR DESCRIPTION
Fixes #27 

This PR adds a `--template` flag to the `CLI`, which allows the user to specify which domain template that want to use to build the domain.

The internals of how the `Models::Domain` interacts with the `aws-sdk` has been updated. A new `Providers::Domain::AWS` adaptor has been implement to handle the `aws` specifics. It is initialised with a `Domain` model and delegates all the model attributes to it. It does however contain the `aws` specific code for deploying a domain.

The only catch is deploying a machine is very similar to deploying a domain. Thus the `deploy_aws` method has been located in a `DeployAWS` mixin. It contains the setup for `CloudFormations` and the deploy method itself. It is then up to the `Providers::Domain::AWS` adaptor to configure the deploy inputs to work with it.

Finally, the domain name does not need to be globally unique anymore. Instead it only needs to be unique within a region. This makes creating the domain easier as it doesn't need to check for the domain in advance, instead it just need to catch an error.