### PR TITLE
Refactor the `machine create` to cache network requests

### DIFF
--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -125,7 +125,7 @@ module Cloudware
     end
 
     command :'machine create' do |c|
-      c.syntax = 'flightconnector machine create [options]'
+      c.syntax = 'flightconnector machine create NAME [options]'
       c.description = 'Create a new machine'
       c.option '--name NAME', String, 'Machine name'
       c.option '--domain NAME', String, 'Domain name'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -129,7 +129,8 @@ module Cloudware
       c.description = 'Create a new machine'
       c.option '--name NAME', String, 'Machine name'
       c.option '-d', '--domain NAME', String, 'Domain name'
-      c.option '--role NAME', String, 'Machine role to inherit (master or slave)'
+      c.option '-r', '--role NAME', String,
+               'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String, 'Pri subnet IP address'
       c.option '--type NAME', String,
                { default: 'small' },

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -131,8 +131,13 @@ module Cloudware
       c.option '--domain NAME', String, 'Domain name'
       c.option '--role NAME', String, 'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String, 'Pri subnet IP address'
-      c.option '--type NAME', String, 'Flavour of machine type to deploy, e.g. medium'
-      c.option '--flavour NAME', String, 'Type of machine to deploy, e.g. gpu'
+      c.option '--type NAME', String,
+               { default: 'small' },
+               'Flavour of machine type to deploy, e.g. medium'
+      c.option '--flavour NAME', String,
+               { default: 'compute' },
+               'Type of machine to deploy, e.g. gpu'
+
       c.hidden = true
       action(c, Commands::Machine::Create)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -132,7 +132,6 @@ module Cloudware
       c.option '--role NAME', String,
                'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String,
-               { default: '10.0.1.1' },
                'Pri subnet IP address'
       c.option '--type NAME', String,
                { default: 'small' },

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -127,7 +127,6 @@ module Cloudware
     command :'machine create' do |c|
       c.syntax = 'flightconnector machine create NAME [options]'
       c.description = 'Create a new machine'
-      c.option '--name NAME', String, 'Machine name'
       c.option '-d', '--domain NAME', String, 'Domain name'
       c.option '-r', '--role NAME', String,
                'Machine role to inherit (master or slave)'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -128,7 +128,7 @@ module Cloudware
       c.syntax = 'flightconnector machine create NAME [options]'
       c.description = 'Create a new machine'
       c.option '--name NAME', String, 'Machine name'
-      c.option '--domain NAME', String, 'Domain name'
+      c.option '-d', '--domain NAME', String, 'Domain name'
       c.option '--role NAME', String, 'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String, 'Pri subnet IP address'
       c.option '--type NAME', String,

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -127,8 +127,9 @@ module Cloudware
     command :'machine create' do |c|
       c.syntax = 'flightconnector machine create NAME [options]'
       c.description = 'Create a new machine'
+      provider_and_region_options(c)
       c.option '-d', '--domain NAME', String, 'Domain name'
-      c.option '-r', '--role NAME', String,
+      c.option '--role NAME', String,
                'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String,
                { default: '10.0.1.1' },

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -131,7 +131,9 @@ module Cloudware
       c.option '-d', '--domain NAME', String, 'Domain name'
       c.option '-r', '--role NAME', String,
                'Machine role to inherit (master or slave)'
-      c.option '--priip ADDR', String, 'Pri subnet IP address'
+      c.option '--priip ADDR', String,
+               { default: '10.0.1.1' },
+               'Pri subnet IP address'
       c.option '--type NAME', String,
                { default: 'small' },
                'Flavour of machine type to deploy, e.g. medium'

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -49,10 +49,12 @@ module Cloudware
 
     def run_whirly(status)
       update_status = proc { |s| Whirly.status = s.bold }
+      result = nil
       Whirly.start do
         update_status.call(status)
-        yield update_status if block_given?
+        result = yield update_status if block_given?
       end
+      result
     end
   end
 end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -5,6 +5,7 @@ module Cloudware
     module Machine
       class Create < Command
         def run
+          domain
           m = Cloudware::Machine.new
           d = Cloudware::Domain.new
 
@@ -18,10 +19,6 @@ module Cloudware
           m.role = options.role
 
           m.priip = options.priip.to_s
-
-          run_whirly('Verifying domain exists') do
-            raise("Domain #{options.domain} does not exist") unless m.valid_domain?
-          end
 
           run_whirly('Checking machine name is valid') do |update_status|
             raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
@@ -44,6 +41,14 @@ module Cloudware
 
         def required_options
           [:domain, :role, :priip, :flavour, :type]
+        end
+
+        def domain
+          d = Providers.find_domain(
+            options.provider, options.region, options.domain
+          )
+          return d if d
+          raise InvalidInput, "Can not find '#{options.domain}' domain"
         end
       end
     end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -11,8 +11,7 @@ module Cloudware
           m.type = options.type.to_s
           m.flavour = options.flavour.to_s
 
-          options.name = ask('Machine name: ') if options.name.nil?
-          m.name = options.name.to_s
+          m.name = name
 
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           m.domain = options.domain.to_s
@@ -38,6 +37,14 @@ module Cloudware
             m.create
           end
         end
+
+        def unpack_args
+          @name = args.first
+        end
+
+        private
+
+        attr_reader :name
       end
     end
   end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -17,7 +17,6 @@ module Cloudware
 
           m.role = options.role
 
-          options.priip = ask('Pri subnet IP: ') if options.priip.nil?
           m.priip = options.priip.to_s
 
           run_whirly('Verifying domain exists') do
@@ -44,7 +43,7 @@ module Cloudware
         attr_reader :name
 
         def required_options
-          [:domain, :role]
+          [:domain, :role, :priip]
         end
       end
     end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -12,7 +12,7 @@ module Cloudware
               type: options.type,
               flavour: options.flavour,
               role: options.role,
-              priip: options.role
+              priip: options.priip
             ).create!
           end
         end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -43,7 +43,7 @@ module Cloudware
         attr_reader :name
 
         def required_options
-          [:domain, :role, :priip]
+          [:domain, :role, :priip, :flavour, :type]
         end
       end
     end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -5,26 +5,15 @@ module Cloudware
     module Machine
       class Create < Command
         def run
-          machine = Cloudware::Models::Machine.build(
-            domain: domain,
-            name: name,
-            type: options.type,
-            flavour: options.flavour,
-            role: options.role,
-            priip: options.role
-          )
-
-          m = Cloudware::Machine.new
-
-          m.type = options.type.to_s
-          m.flavour = options.flavour.to_s
-          m.name = name
-          m.domain = options.domain
-          m.role = options.role
-          m.priip = options.priip.to_s
-
           run_whirly('Creating new deployment') do
-            m.create
+            Cloudware::Models::Machine.build(
+              domain: domain,
+              name: name,
+              type: options.type,
+              flavour: options.flavour,
+              role: options.role,
+              priip: options.role
+            ).create!
           end
         end
 

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -44,10 +44,14 @@ module Cloudware
         end
 
         def domain
-          d = Providers.find_domain(
-            options.provider, options.region, options.domain
-          )
-          return d if d
+          @domain ||= begin
+            run_whirly('Searching for domain') do
+              Providers.find_domain(
+                options.provider, options.region, options.domain
+              )
+            end
+          end
+          return @domain if @domain
           raise InvalidInput, "Can not find '#{options.domain}' domain"
         end
       end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -6,16 +6,22 @@ module Cloudware
       class Create < Command
         def run
           domain
+          machine = Cloudware::Models::Machine.build(
+            name: name,
+            type: options.type,
+            flavour: options.flavour,
+            domain: domain,
+            role: options.role,
+            priip: options.role
+          )
+
           m = Cloudware::Machine.new
 
           m.type = options.type.to_s
           m.flavour = options.flavour.to_s
           m.name = name
-
           m.domain = options.domain
-
           m.role = options.role
-
           m.priip = options.priip.to_s
 
           run_whirly('Creating new deployment') do

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -10,12 +10,10 @@ module Cloudware
 
           m.type = options.type.to_s
           m.flavour = options.flavour.to_s
-
           m.name = name
 
-          options.domain = ask('Domain identifier: ') if options.domain.nil?
-          m.domain = options.domain.to_s
-          d.name = options.domain.to_s
+          m.domain = options.domain
+          d.name = options.domain
 
           options.role = choose('Machine role?', :master, :slave) if options.role.nil?
           m.role = options.role.to_s
@@ -45,6 +43,10 @@ module Cloudware
         private
 
         attr_reader :name
+
+        def required_options
+          [:domain]
+        end
       end
     end
   end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -5,12 +5,11 @@ module Cloudware
     module Machine
       class Create < Command
         def run
-          domain
           machine = Cloudware::Models::Machine.build(
+            domain: domain,
             name: name,
             type: options.type,
             flavour: options.flavour,
-            domain: domain,
             role: options.role,
             priip: options.role
           )
@@ -43,11 +42,9 @@ module Cloudware
 
         def domain
           @domain ||= begin
-            run_whirly('Searching for domain') do
-              Providers.find_domain(
-                options.provider, options.region, options.domain
-              )
-            end
+            Providers.find_domain(
+              options.provider, options.region, options.domain
+            )
           end
           return @domain if @domain
           raise InvalidInput, "Can not find '#{options.domain}' domain"

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -15,8 +15,7 @@ module Cloudware
           m.domain = options.domain
           d.name = options.domain
 
-          options.role = choose('Machine role?', :master, :slave) if options.role.nil?
-          m.role = options.role.to_s
+          m.role = options.role
 
           options.priip = ask('Pri subnet IP: ') if options.priip.nil?
           m.priip = options.priip.to_s
@@ -45,7 +44,7 @@ module Cloudware
         attr_reader :name
 
         def required_options
-          [:domain]
+          [:domain, :role]
         end
       end
     end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -7,24 +7,16 @@ module Cloudware
         def run
           domain
           m = Cloudware::Machine.new
-          d = Cloudware::Domain.new
 
           m.type = options.type.to_s
           m.flavour = options.flavour.to_s
           m.name = name
 
           m.domain = options.domain
-          d.name = options.domain
 
           m.role = options.role
 
           m.priip = options.priip.to_s
-
-          run_whirly('Checking machine name is valid') do |update_status|
-            raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
-            update_status.call('Verifying pri IP address')
-            raise("Invalid pri IP address #{options.priip} in subnet #{d.get_item('pri_subnet_cidr')}") unless m.valid_ip?(d.get_item('pri_subnet_cidr').to_s, options.priip.to_s)
-          end
 
           run_whirly('Creating new deployment') do
             m.create

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -5,8 +5,6 @@ module Cloudware
     module Machine
       class Create < Command
         def run
-          options.default flavour: 'compute', type: 'small'
-
           m = Cloudware::Machine.new
           d = Cloudware::Domain.new
 

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -36,8 +36,7 @@ module Cloudware
       end
 
       def validate_cloudware_domain_exists
-        domains = Providers.select(provider)::Domains.by_region(region)
-        return true if domains.find_by_name(name)
+        return true if Providers.find_domain(provider, region, name)
         errors.add(:domain, 'does not exist')
       end
 

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -8,7 +8,8 @@ module Cloudware
     class Domain < Application
       ATTRIBUTES = [
         :name, :provider, :region, :networkcidr, :prisubnetcidr, :template,
-        :cluster_index, :create_domain_already_exists_flag
+        :cluster_index, :create_domain_already_exists_flag,
+        :network_id, :prisubnet_id, # TODO: Remove the aws specific id's
       ].freeze
       attr_accessor(*ATTRIBUTES)
 

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -17,8 +17,8 @@ module Cloudware
 
       private
 
-      def provider_module
-        Providers.select(provider)
+      def provider_machine
+        Providers.select(provider)::Machine.new(self)
       end
     end
   end

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -13,6 +13,7 @@ module Cloudware
       delegate(*DOMAIN_ATTRIBUTES, to: :domain)
 
       def run_create
+        provider_machine.create
       end
 
       private

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -3,7 +3,23 @@ module Cloudware
   module Models
     class Machine < Application
       ATTRIBUTES = [:name, :type, :flavour, :domain, :role, :priip]
+      DOMAIN_ATTRIBUTES = [:region, :provider]
+
+      def self.delegate_attributes
+        ATTRIBUTES.dup.concat(DOMAIN_ATTRIBUTES.dup)
+      end
+
       attr_accessor(*ATTRIBUTES)
+      delegate(*DOMAIN_ATTRIBUTES, to: :domain)
+
+      def run_create
+      end
+
+      private
+
+      def provider_module
+        Providers.select(provider)
+      end
     end
   end
 end

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -1,0 +1,9 @@
+
+module Cloudware
+  module Models
+    class Machine < Application
+      ATTRIBUTES = [:name, :type, :flavour, :domain, :role, :priip]
+      attr_accessor(*ATTRIBUTES)
+    end
+  end
+end

--- a/lib/cloudware/providers.rb
+++ b/lib/cloudware/providers.rb
@@ -17,6 +17,10 @@ module Cloudware
           raise InvalidInput, "Unrecognised provider: #{provider}"
         end
       end
+
+      def find_domain(provider, region, name)
+        select(provider)::Domains.by_region(region).find_by_name(name)
+      end
     end
   end
 end

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -49,7 +49,9 @@ module Cloudware
               domain.name = vpc_tags.cloudware_domain
               domain.networkcidr = vpc_tags.cloudware_network_cidr
               domain.prisubnetcidr = vpc_tags.cloudware_pri_subnet_cidr
-              pp subnet = find_subnet(domain.name).original_ec2
+
+              subnet = find_subnet(domain.name)
+              domain.prisubnet_id = subnet.original_ec2.subnet_id
             end
           end
 

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -37,9 +37,7 @@ module Cloudware
           end
 
           def find_subnet(domain_name)
-            subnets.find do |net|
-              net.cloudware_domain == domain_name
-            end
+            subnets.find { |net| net.cloudware_domain == domain_name }
           end
 
           def build_domain(vpc)

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -47,6 +47,7 @@ module Cloudware
               domain.name = vpc_tags.cloudware_domain
               domain.networkcidr = vpc_tags.cloudware_network_cidr
               domain.prisubnetcidr = vpc_tags.cloudware_pri_subnet_cidr
+              domain.network_id = vpc.vpc_id
 
               subnet = find_subnet(domain.name)
               domain.prisubnet_id = subnet.original_ec2.subnet_id

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -28,12 +28,18 @@ module Cloudware
             ).vpcs
           end
 
-          # Ported code
-          # def subnets
-          #   @subnets ||= ec2.describe_subnets(
-          #     filters: [{ name: 'tag-key', values: ['cloudware_id'] }]
-          #   ).subnets
-          # end
+          def subnets
+            @subnets ||= ec2.describe_subnets(
+              filters: [{ name: 'tag-key', values: ['cloudware_id'] }]
+            ).subnets
+          end
+
+          def find_subnet(domain_name)
+            subnets.find do |net|
+              tags = net.tags.map { |t| [t.key, t.value] }.to_h
+              tags['cloudware_domain'] == domain_name
+            end
+          end
 
           def build_domain(vpc)
             args = { provider: 'aws', region: region }
@@ -48,6 +54,7 @@ module Cloudware
                   domain.prisubnetcidr = tag.value
                 end
               end
+              subnet = find_subnet(domain.name)
             end
           end
         end

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -31,13 +31,14 @@ module Cloudware
           def subnets
             @subnets ||= ec2.describe_subnets(
               filters: [{ name: 'tag-key', values: ['cloudware_id'] }]
-            ).subnets
+            ).subnets.map do |net|
+              tags_structs(net.tags).tap { |t| t.original_ec2 = net }
+            end
           end
 
           def find_subnet(domain_name)
             subnets.find do |net|
-              tags = tags_structs(net.tags)
-              tags.cloudware_domain == domain_name
+              net.cloudware_domain == domain_name
             end
           end
 
@@ -48,7 +49,7 @@ module Cloudware
               domain.name = vpc_tags.cloudware_domain
               domain.networkcidr = vpc_tags.cloudware_network_cidr
               domain.prisubnetcidr = vpc_tags.cloudware_pri_subnet_cidr
-              subnet = find_subnet(domain.name)
+              pp subnet = find_subnet(domain.name).original_ec2
             end
           end
 

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -3,6 +3,52 @@ module Cloudware
   module Providers
     module AWS
       class Machine < Base::Machine
+        include DeployAWS
+
+        def create
+          deploy_aws
+        end
+
+        private
+
+        def id
+          @id ||= SecureRandom.uuid
+        end
+
+        def deploy_parameters
+          [
+            {
+              parameter_key: 'cloudwareDomain',
+              parameter_value: domain.name
+            },
+            { parameter_key: 'cloudwareId', parameter_value: id },
+            { parameter_key: 'priIp', parameter_value: priip },
+            { parameter_key: 'vmRole', parameter_value: role },
+            { parameter_key: 'vmType', parameter_value: type },
+            { parameter_key: 'vmName', parameter_value: name },
+            {
+              parameter_key: 'networkId',
+              parameter_value: domain.network_id
+            },
+            {
+              parameter_key: 'priSubnetId',
+              parameter_value: domain.pri_subnet_id
+            },
+            {
+              parameter_key: 'priSubnetCidr',
+              parameter_value: domain.pri_subnet_cidr
+            },
+            { parameter_key: 'vmFlavour', parameter_value: flavour },
+          ]
+        end
+
+        def deploy_template_content
+          path = File.join(
+            Cloudware.config.base_dir,
+            "providers/aws/templates/machine-#{role}.yml"
+          )
+          File.read(path)
+        end
       end
     end
   end

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -11,6 +11,10 @@ module Cloudware
 
         private
 
+        def aws_type
+          machine_mappings[flavour][type]
+        end
+
         def id
           @id ||= SecureRandom.uuid
         end
@@ -24,7 +28,7 @@ module Cloudware
             { parameter_key: 'cloudwareId', parameter_value: id },
             { parameter_key: 'priIp', parameter_value: priip },
             { parameter_key: 'vmRole', parameter_value: role },
-            { parameter_key: 'vmType', parameter_value: type },
+            { parameter_key: 'vmType', parameter_value: aws_type },
             { parameter_key: 'vmName', parameter_value: name },
             {
               parameter_key: 'networkId',
@@ -48,6 +52,13 @@ module Cloudware
             "providers/aws/templates/machine-#{role}.yml"
           )
           File.read(path)
+        end
+
+        def machine_mappings
+          @machine_mappings ||= YAML.load_file(File.join(
+            Cloudware.config.base_dir,
+              "providers/aws/mappings/machine_types.yml"
+          ))
         end
       end
     end

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -32,11 +32,11 @@ module Cloudware
             },
             {
               parameter_key: 'priSubnetId',
-              parameter_value: domain.pri_subnet_id
+              parameter_value: domain.prisubnet_id
             },
             {
               parameter_key: 'priSubnetCidr',
-              parameter_value: domain.pri_subnet_cidr
+              parameter_value: domain.prisubnetcidr
             },
             { parameter_key: 'vmFlavour', parameter_value: flavour },
           ]

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -1,0 +1,9 @@
+
+module Cloudware
+  module Providers
+    module AWS
+      class Machine < Base::Machine
+      end
+    end
+  end
+end

--- a/lib/cloudware/providers/base/machine.rb
+++ b/lib/cloudware/providers/base/machine.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Cloudware
+  module Providers
+    module Base
+      class Machine
+        def initialize(machine_model)
+          @machine_model = machine_model
+        end
+
+        def create
+          raise NotImplementedError
+        end
+
+        def destroy
+          raise NotImplementedError
+        end
+
+        private
+
+        attr_reader :machine_model
+
+        delegate(*Models::Machine.delegate_attributes, to: :machine_model)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR updates how machines are created so that network requests are cached. Broadly the exact same design pattern as `domain create` is made. This required updating the `CLI` to remove the highline questions and introducing `Models::Machine` and `AWS::Machine` just like `Domain`.

The `Models::Domain` had to be updated so that it contained the `subnet` information. The request for the subnet information is made up front and cached for latter use. It is then used to add additional information about the domain.

Otherwise the final commits tweak the `CLI` input so the templates work correctly.