### PR TITLE
Refactor `machine info` and `machine rebuild`

### DIFF
--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -154,11 +154,9 @@ module Cloudware
     end
 
     command :'machine info' do |c|
-      c.syntax = 'flightconnector machine info [options]'
+      c.syntax = 'flightconnector machine info NAME [options]'
       c.description = 'List detailed information about a given machine'
-      c.option '--name NAME', String, 'Machine name'
-      c.option '--domain NAME', String, 'Domain name'
-      c.option '--output TYPE', String, 'Output type [table]. Default: table'
+      provider_and_region_options(c)
       c.hidden = true
       action(c, Commands::Machine::Info)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -125,7 +125,7 @@ module Cloudware
     end
 
     command :'machine create' do |c|
-      c.syntax = 'flightconnector machine create [options]'
+      c.syntax = 'flightconnector machine create NAME [options]'
       c.description = 'Create a new machine'
       c.option '--name NAME', String, 'Machine name'
       c.option '--domain NAME', String, 'Domain name'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -129,7 +129,8 @@ module Cloudware
       c.description = 'Create a new machine'
       c.option '--name NAME', String, 'Machine name'
       c.option '-d', '--domain NAME', String, 'Domain name'
-      c.option '--role NAME', String, 'Machine role to inherit (master or slave)'
+      c.option '-r', '--role NAME', String,
+               'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String, 'Pri subnet IP address'
       c.option '--type NAME', String,
                { default: 'small' },

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -148,6 +148,7 @@ module Cloudware
       c.syntax = 'flightconnector machine list'
       c.option '--provider NAME', String, 'Cloud provider to show machines for'
       c.description = 'List available machines'
+      provider_and_region_options(c)
       c.hidden = true
       action(c, Commands::Machine::List)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -197,10 +197,9 @@ module Cloudware
     end
 
     command :'machine rebuild' do |c|
-      c.syntax = 'flightconnector machine rebuild [options]'
+      c.syntax = 'flightconnector machine rebuild NAME [options]'
       c.description = 'Rebuild a machine'
-      c.option '--name NAME', String, 'Machine name'
-      c.option '--domain NAME', String, 'Domain identifier'
+      provider_and_region_options(c)
       c.hidden = true
       action(c, Commands::Machine::Rebuild)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -131,8 +131,13 @@ module Cloudware
       c.option '--domain NAME', String, 'Domain name'
       c.option '--role NAME', String, 'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String, 'Pri subnet IP address'
-      c.option '--type NAME', String, 'Flavour of machine type to deploy, e.g. medium'
-      c.option '--flavour NAME', String, 'Type of machine to deploy, e.g. gpu'
+      c.option '--type NAME', String,
+               { default: 'small' },
+               'Flavour of machine type to deploy, e.g. medium'
+      c.option '--flavour NAME', String,
+               { default: 'compute' },
+               'Type of machine to deploy, e.g. gpu'
+
       c.hidden = true
       action(c, Commands::Machine::Create)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -132,7 +132,6 @@ module Cloudware
       c.option '--role NAME', String,
                'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String,
-               { default: '10.0.1.1' },
                'Pri subnet IP address'
       c.option '--type NAME', String,
                { default: 'small' },

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -127,7 +127,6 @@ module Cloudware
     command :'machine create' do |c|
       c.syntax = 'flightconnector machine create NAME [options]'
       c.description = 'Create a new machine'
-      c.option '--name NAME', String, 'Machine name'
       c.option '-d', '--domain NAME', String, 'Domain name'
       c.option '-r', '--role NAME', String,
                'Machine role to inherit (master or slave)'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -128,7 +128,7 @@ module Cloudware
       c.syntax = 'flightconnector machine create NAME [options]'
       c.description = 'Create a new machine'
       c.option '--name NAME', String, 'Machine name'
-      c.option '--domain NAME', String, 'Domain name'
+      c.option '-d', '--domain NAME', String, 'Domain name'
       c.option '--role NAME', String, 'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String, 'Pri subnet IP address'
       c.option '--type NAME', String,

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -164,10 +164,9 @@ module Cloudware
     end
 
     command :'machine destroy' do |c|
-      c.syntax = 'flightconnector machine destroy [options]'
+      c.syntax = 'flightconnector machine destroy NAME [options]'
       c.description = 'Destroy a machine'
-      c.option '--name NAME', String, 'Machine name'
-      c.option '--domain NAME', String, 'Domain identifier'
+      provider_and_region_options(c)
       c.hidden = true
       action(c, Commands::Machine::Destroy)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -127,8 +127,9 @@ module Cloudware
     command :'machine create' do |c|
       c.syntax = 'flightconnector machine create NAME [options]'
       c.description = 'Create a new machine'
+      provider_and_region_options(c)
       c.option '-d', '--domain NAME', String, 'Domain name'
-      c.option '-r', '--role NAME', String,
+      c.option '--role NAME', String,
                'Machine role to inherit (master or slave)'
       c.option '--priip ADDR', String,
                { default: '10.0.1.1' },

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -131,7 +131,9 @@ module Cloudware
       c.option '-d', '--domain NAME', String, 'Domain name'
       c.option '-r', '--role NAME', String,
                'Machine role to inherit (master or slave)'
-      c.option '--priip ADDR', String, 'Pri subnet IP address'
+      c.option '--priip ADDR', String,
+               { default: '10.0.1.1' },
+               'Pri subnet IP address'
       c.option '--type NAME', String,
                { default: 'small' },
                'Flavour of machine type to deploy, e.g. medium'

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -49,10 +49,12 @@ module Cloudware
 
     def run_whirly(status)
       update_status = proc { |s| Whirly.status = s.bold }
+      result = nil
       Whirly.start do
         update_status.call(status)
-        yield update_status if block_given?
+        result = yield update_status if block_given?
       end
+      result
     end
   end
 end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -5,6 +5,7 @@ module Cloudware
     module Machine
       class Create < Command
         def run
+          domain
           m = Cloudware::Machine.new
           d = Cloudware::Domain.new
 
@@ -18,10 +19,6 @@ module Cloudware
           m.role = options.role
 
           m.priip = options.priip.to_s
-
-          run_whirly('Verifying domain exists') do
-            raise("Domain #{options.domain} does not exist") unless m.valid_domain?
-          end
 
           run_whirly('Checking machine name is valid') do |update_status|
             raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
@@ -44,6 +41,14 @@ module Cloudware
 
         def required_options
           [:domain, :role, :priip, :flavour, :type]
+        end
+
+        def domain
+          d = Providers.find_domain(
+            options.provider, options.region, options.domain
+          )
+          return d if d
+          raise InvalidInput, "Can not find '#{options.domain}' domain"
         end
       end
     end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -11,8 +11,7 @@ module Cloudware
           m.type = options.type.to_s
           m.flavour = options.flavour.to_s
 
-          options.name = ask('Machine name: ') if options.name.nil?
-          m.name = options.name.to_s
+          m.name = name
 
           options.domain = ask('Domain identifier: ') if options.domain.nil?
           m.domain = options.domain.to_s
@@ -38,6 +37,14 @@ module Cloudware
             m.create
           end
         end
+
+        def unpack_args
+          @name = args.first
+        end
+
+        private
+
+        attr_reader :name
       end
     end
   end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -17,7 +17,6 @@ module Cloudware
 
           m.role = options.role
 
-          options.priip = ask('Pri subnet IP: ') if options.priip.nil?
           m.priip = options.priip.to_s
 
           run_whirly('Verifying domain exists') do
@@ -44,7 +43,7 @@ module Cloudware
         attr_reader :name
 
         def required_options
-          [:domain, :role]
+          [:domain, :role, :priip]
         end
       end
     end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -12,7 +12,7 @@ module Cloudware
               type: options.type,
               flavour: options.flavour,
               role: options.role,
-              priip: options.role
+              priip: options.priip
             ).create!
           end
         end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -43,7 +43,7 @@ module Cloudware
         attr_reader :name
 
         def required_options
-          [:domain, :role, :priip]
+          [:domain, :role, :priip, :flavour, :type]
         end
       end
     end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -5,26 +5,15 @@ module Cloudware
     module Machine
       class Create < Command
         def run
-          machine = Cloudware::Models::Machine.build(
-            domain: domain,
-            name: name,
-            type: options.type,
-            flavour: options.flavour,
-            role: options.role,
-            priip: options.role
-          )
-
-          m = Cloudware::Machine.new
-
-          m.type = options.type.to_s
-          m.flavour = options.flavour.to_s
-          m.name = name
-          m.domain = options.domain
-          m.role = options.role
-          m.priip = options.priip.to_s
-
           run_whirly('Creating new deployment') do
-            m.create
+            Cloudware::Models::Machine.build(
+              domain: domain,
+              name: name,
+              type: options.type,
+              flavour: options.flavour,
+              role: options.role,
+              priip: options.role
+            ).create!
           end
         end
 

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -44,10 +44,14 @@ module Cloudware
         end
 
         def domain
-          d = Providers.find_domain(
-            options.provider, options.region, options.domain
-          )
-          return d if d
+          @domain ||= begin
+            run_whirly('Searching for domain') do
+              Providers.find_domain(
+                options.provider, options.region, options.domain
+              )
+            end
+          end
+          return @domain if @domain
           raise InvalidInput, "Can not find '#{options.domain}' domain"
         end
       end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -6,16 +6,22 @@ module Cloudware
       class Create < Command
         def run
           domain
+          machine = Cloudware::Models::Machine.build(
+            name: name,
+            type: options.type,
+            flavour: options.flavour,
+            domain: domain,
+            role: options.role,
+            priip: options.role
+          )
+
           m = Cloudware::Machine.new
 
           m.type = options.type.to_s
           m.flavour = options.flavour.to_s
           m.name = name
-
           m.domain = options.domain
-
           m.role = options.role
-
           m.priip = options.priip.to_s
 
           run_whirly('Creating new deployment') do

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -10,12 +10,10 @@ module Cloudware
 
           m.type = options.type.to_s
           m.flavour = options.flavour.to_s
-
           m.name = name
 
-          options.domain = ask('Domain identifier: ') if options.domain.nil?
-          m.domain = options.domain.to_s
-          d.name = options.domain.to_s
+          m.domain = options.domain
+          d.name = options.domain
 
           options.role = choose('Machine role?', :master, :slave) if options.role.nil?
           m.role = options.role.to_s
@@ -45,6 +43,10 @@ module Cloudware
         private
 
         attr_reader :name
+
+        def required_options
+          [:domain]
+        end
       end
     end
   end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -5,12 +5,11 @@ module Cloudware
     module Machine
       class Create < Command
         def run
-          domain
           machine = Cloudware::Models::Machine.build(
+            domain: domain,
             name: name,
             type: options.type,
             flavour: options.flavour,
-            domain: domain,
             role: options.role,
             priip: options.role
           )
@@ -43,11 +42,9 @@ module Cloudware
 
         def domain
           @domain ||= begin
-            run_whirly('Searching for domain') do
-              Providers.find_domain(
-                options.provider, options.region, options.domain
-              )
-            end
+            Providers.find_domain(
+              options.provider, options.region, options.domain
+            )
           end
           return @domain if @domain
           raise InvalidInput, "Can not find '#{options.domain}' domain"

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -15,8 +15,7 @@ module Cloudware
           m.domain = options.domain
           d.name = options.domain
 
-          options.role = choose('Machine role?', :master, :slave) if options.role.nil?
-          m.role = options.role.to_s
+          m.role = options.role
 
           options.priip = ask('Pri subnet IP: ') if options.priip.nil?
           m.priip = options.priip.to_s
@@ -45,7 +44,7 @@ module Cloudware
         attr_reader :name
 
         def required_options
-          [:domain]
+          [:domain, :role]
         end
       end
     end

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -7,24 +7,16 @@ module Cloudware
         def run
           domain
           m = Cloudware::Machine.new
-          d = Cloudware::Domain.new
 
           m.type = options.type.to_s
           m.flavour = options.flavour.to_s
           m.name = name
 
           m.domain = options.domain
-          d.name = options.domain
 
           m.role = options.role
 
           m.priip = options.priip.to_s
-
-          run_whirly('Checking machine name is valid') do |update_status|
-            raise("Machine name #{options.name} is not a valid machine name") unless m.validate_name?
-            update_status.call('Verifying pri IP address')
-            raise("Invalid pri IP address #{options.priip} in subnet #{d.get_item('pri_subnet_cidr')}") unless m.valid_ip?(d.get_item('pri_subnet_cidr').to_s, options.priip.to_s)
-          end
 
           run_whirly('Creating new deployment') do
             m.create

--- a/lib/cloudware/commands/machine/create.rb
+++ b/lib/cloudware/commands/machine/create.rb
@@ -5,8 +5,6 @@ module Cloudware
     module Machine
       class Create < Command
         def run
-          options.default flavour: 'compute', type: 'small'
-
           m = Cloudware::Machine.new
           d = Cloudware::Domain.new
 

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -6,11 +6,12 @@ module Cloudware
       class Destroy < Command
         def run
           run_whirly("Destroying: '#{name}'") do
-            pp Providers.find_machine(
+            Providers.find_machine(
               options.provider,
               options.region,
               name
-            )
+            ).tap { |m| raise_if_machine_is_missing(m) }
+
           end
         end
 
@@ -20,6 +21,11 @@ module Cloudware
 
         def unpack_args
           @name = args.first
+        end
+
+        def raise_if_machine_is_missing(machine)
+          return if machine
+          raise InvalidInput, "Could not find machine: '#{name}'"
         end
       end
     end

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -5,21 +5,21 @@ module Cloudware
     module Machine
       class Destroy < Command
         def run
-          m = Cloudware::Machine.new
-
-          options.name = ask('Machine name: ') if options.name.nil?
-          m.name = options.name.to_s
-
-          options.domain = ask('Domain identifier: ') if options.domain.nil?
-          m.domain = options.domain.to_s
-
-          run_whirly('Checking machine exists') do
-            raise('Machine does not exist') unless m.exists?
+          run_whirly("Destroying: '#{name}'") do
+            pp Providers.find_machine(
+              options.provider,
+              options.region,
+              name
+            )
           end
+        end
 
-          run_whirly("Destroying #{options.name} in domain #{options.domain}") do
-            m.destroy
-          end
+        private
+
+        attr_reader :name
+
+        def unpack_args
+          @name = args.first
         end
       end
     end

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -9,9 +9,9 @@ module Cloudware
             Providers.find_machine(
               options.provider,
               options.region,
-              name
-            ).tap { |m| raise_if_machine_is_missing(m) }
-             .destroy!
+              name,
+              missing_error: true
+            ).destroy!
           end
         end
 
@@ -21,11 +21,6 @@ module Cloudware
 
         def unpack_args
           @name = args.first
-        end
-
-        def raise_if_machine_is_missing(machine)
-          return if machine
-          raise InvalidInput, "Could not find machine: '#{name}'"
         end
       end
     end

--- a/lib/cloudware/commands/machine/destroy.rb
+++ b/lib/cloudware/commands/machine/destroy.rb
@@ -11,7 +11,7 @@ module Cloudware
               options.region,
               name
             ).tap { |m| raise_if_machine_is_missing(m) }
-
+             .destroy!
           end
         end
 

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -19,7 +19,7 @@ module Cloudware
               t.add_row ['Pri subnet IP'.bold, m.priip]
               t.add_row ['External IP'.bold, m.extip]
               t.add_row ['Machine state'.bold, m.state]
-              t.add_row ['Machine type'.bold, m.type]
+              t.add_row ['Machine type'.bold, m.provider_type]
               t.add_row ['Machine flavour'.bold, m.flavour]
               t.add_row ['Provider'.bold, m.provider]
               t.style = { all_separators: true }

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -5,31 +5,35 @@ module Cloudware
     module Machine
       class Info < Command
         def run
-          options.default output: 'table'
-          m = Cloudware::Machine.new
-          options.domain = ask('Domain name?') if options.domain.nil?
-          options.name = ask('Machine name?') if options.name.nil?
-          m.name = options.name.to_s
-          m.domain = options.domain.to_s
-
-          case options.output.to_s
-          when 'table'
-            table = Terminal::Table.new do |t|
-              run_whirly('Fetching machine info') do
-                t.add_row ['Machine name'.bold, m.name]
-                t.add_row ['Domain name'.bold, m.get_item('domain')]
-                t.add_row ['Machine role'.bold, m.get_item('role')]
-                t.add_row ['Pri subnet IP'.bold, m.get_item('pri_ip')]
-                t.add_row ['External IP'.bold, m.get_item('ext_ip')]
-                t.add_row ['Machine state'.bold, m.get_item('state')]
-                t.add_row ['Machine type'.bold, m.get_item('type')]
-                t.add_row ['Machine flavour'.bold, m.get_item('flavour')]
-                t.add_row ['Provider'.bold, m.get_item('provider')]
-              end
+          table = run_whirly('Fetching machine info') do
+            m = Providers.find_machine(
+              options.provider,
+              options.region,
+              name,
+              missing_error: true
+            )
+            Terminal::Table.new do |t|
+              t.add_row ['Machine name'.bold, m.name]
+              t.add_row ['Domain name'.bold, m.get_item('domain')]
+              t.add_row ['Machine role'.bold, m.get_item('role')]
+              t.add_row ['Pri subnet IP'.bold, m.get_item('pri_ip')]
+              t.add_row ['External IP'.bold, m.get_item('ext_ip')]
+              t.add_row ['Machine state'.bold, m.get_item('state')]
+              t.add_row ['Machine type'.bold, m.get_item('type')]
+              t.add_row ['Machine flavour'.bold, m.get_item('flavour')]
+              t.add_row ['Provider'.bold, m.get_item('provider')]
               t.style = { all_separators: true }
             end
-            puts table
           end
+          puts table
+        end
+
+        private
+
+        attr_reader :name
+
+        def unpack_args
+          @name = args.first
         end
       end
     end

--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -14,14 +14,14 @@ module Cloudware
             )
             Terminal::Table.new do |t|
               t.add_row ['Machine name'.bold, m.name]
-              t.add_row ['Domain name'.bold, m.get_item('domain')]
-              t.add_row ['Machine role'.bold, m.get_item('role')]
-              t.add_row ['Pri subnet IP'.bold, m.get_item('pri_ip')]
-              t.add_row ['External IP'.bold, m.get_item('ext_ip')]
-              t.add_row ['Machine state'.bold, m.get_item('state')]
-              t.add_row ['Machine type'.bold, m.get_item('type')]
-              t.add_row ['Machine flavour'.bold, m.get_item('flavour')]
-              t.add_row ['Provider'.bold, m.get_item('provider')]
+              t.add_row ['Domain name'.bold, m.domain.name]
+              t.add_row ['Machine role'.bold, m.role]
+              t.add_row ['Pri subnet IP'.bold, m.priip]
+              t.add_row ['External IP'.bold, m.extip]
+              t.add_row ['Machine state'.bold, m.state]
+              t.add_row ['Machine type'.bold, m.type]
+              t.add_row ['Machine flavour'.bold, m.flavour]
+              t.add_row ['Provider'.bold, m.provider]
               t.style = { all_separators: true }
             end
           end

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -6,17 +6,9 @@ module Cloudware
       class List < Command
         def run
           m = Cloudware::Machine.new
-          m.provider = [options.provider] unless options.provider.nil?
-
-          # Exit if the provider is not in the config list (which verifies details ahead of time)
-          if (Cloudware.config.instance_variable_get(:@providers) & m.provider).empty?
-            raise "The provider #{m.provider.join(',')} is not a valid provider - unknown or missing login details"
-          end
+          m.provider = [options.provider]
 
           r = []
-          run_whirly('Fetching available machines') do
-            raise('No available machines') if m.list.nil?
-          end
           m.list.each do |_k, v|
             r << [v[:name], v[:domain], v[:role], v[:pri_ip], v[:type], v[:state]]
           end

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -5,23 +5,25 @@ module Cloudware
     module Machine
       class List < Command
         def run
-          m = Cloudware::Machine.new
-          m.provider = [options.provider]
-
-          machines = Providers.select(options.provider)::Machines
-                       .by_region(options.region)
-
-          r = []
-          m.list.each do |_k, v|
-            r << [v[:name], v[:domain], v[:role], v[:pri_ip], v[:type], v[:state]]
-          end
+          rows = Providers.select(options.provider)::Machines
+                          .by_region(options.region)
+                          .reduce([]) do |memo, machine|
+                            memo << [
+                              machine.name,
+                              machine.domain.name,
+                              machine.role,
+                              machine.priip,
+                              machine.type,
+                              machine.state
+                            ]
+                          end
           table = Terminal::Table.new headings: ['Name'.bold,
                                                  'Domain'.bold,
                                                  'Role'.bold,
                                                  'Pri IP address'.bold,
                                                  'Type'.bold,
                                                  'State'.bold],
-                                      rows: r
+                                      rows: rows
           puts table
         end
       end

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -5,18 +5,21 @@ module Cloudware
     module Machine
       class List < Command
         def run
-          rows = Providers.select(options.provider)::Machines
-                          .by_region(options.region)
-                          .reduce([]) do |memo, machine|
-                            memo << [
-                              machine.name,
-                              machine.domain.name,
-                              machine.role,
-                              machine.priip,
-                              machine.type,
-                              machine.state
-                            ]
-                          end
+          rows = run_whirly('Fetching machines') do
+            Providers.select(options.provider)::Machines
+                     .by_region(options.region)
+                     .reduce([]) do |memo, machine|
+                       memo << [
+                         machine.name,
+                         machine.domain.name,
+                         machine.role,
+                         machine.priip,
+                         machine.type,
+                         machine.state
+                       ]
+                     end
+          end
+
           table = Terminal::Table.new headings: ['Name'.bold,
                                                  'Domain'.bold,
                                                  'Role'.bold,

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -8,6 +8,9 @@ module Cloudware
           m = Cloudware::Machine.new
           m.provider = [options.provider]
 
+          machines = Providers.select(options.provider)::Machines
+                       .by_region(options.region)
+
           r = []
           m.list.each do |_k, v|
             r << [v[:name], v[:domain], v[:role], v[:pri_ip], v[:type], v[:state]]

--- a/lib/cloudware/commands/machine/list.rb
+++ b/lib/cloudware/commands/machine/list.rb
@@ -14,7 +14,7 @@ module Cloudware
                          machine.domain.name,
                          machine.role,
                          machine.priip,
-                         machine.type,
+                         machine.provider_type,
                          machine.state
                        ]
                      end

--- a/lib/cloudware/commands/machine/rebuild.rb
+++ b/lib/cloudware/commands/machine/rebuild.rb
@@ -5,16 +5,24 @@ module Cloudware
     module Machine
       class Rebuild < Command
         def run
-          machine = Cloudware::Machine.new
-          options.name = ask('Machine name: ') if options.name.nil?
-          machine.name = options.name.to_s
-
-          options.domain = ask('Domain identifier: ') if options.domain.nil?
-          machine.domain = options.domain.to_s
-
-          run_whirly("Recreating machine #{options.name}") do
-            machine.rebuild
+          machine = run_whirly('Finding the machine') do
+            Providers.find_machine(
+              options.provider,
+              options.region,
+              name,
+              missing_error: true
+            )
           end
+          run_whirly('Destroying the old machine') { machine.destroy! }
+          run_whirly('Building the new machine') { machine.create! }
+        end
+
+        private
+
+        attr_reader :name
+
+        def unpack_args
+          @name = args.first
         end
       end
     end

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -36,8 +36,7 @@ module Cloudware
       end
 
       def validate_cloudware_domain_exists
-        domains = Providers.select(provider)::Domains.by_region(region)
-        return true if domains.find_by_name(name)
+        return true if Providers.find_domain(provider, region, name)
         errors.add(:domain, 'does not exist')
       end
 

--- a/lib/cloudware/models/domain.rb
+++ b/lib/cloudware/models/domain.rb
@@ -8,7 +8,8 @@ module Cloudware
     class Domain < Application
       ATTRIBUTES = [
         :name, :provider, :region, :networkcidr, :prisubnetcidr, :template,
-        :cluster_index, :create_domain_already_exists_flag
+        :cluster_index, :create_domain_already_exists_flag,
+        :network_id, :prisubnet_id, # TODO: Remove the aws specific id's
       ].freeze
       attr_accessor(*ATTRIBUTES)
 

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -17,8 +17,8 @@ module Cloudware
 
       private
 
-      def provider_module
-        Providers.select(provider)
+      def provider_machine
+        Providers.select(provider)::Machine.new(self)
       end
     end
   end

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -13,6 +13,7 @@ module Cloudware
       delegate(*DOMAIN_ATTRIBUTES, to: :domain)
 
       def run_create
+        provider_machine.create
       end
 
       private

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -4,7 +4,7 @@ module Cloudware
     class Machine < Application
       ATTRIBUTES = [
         :name, :type, :flavour, :domain, :role, :priip, :state, :extip,
-        :instance_id, :id
+        :instance_id, :id, :provider_type
       ]
       DOMAIN_ATTRIBUTES = [:region, :provider]
 

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -15,11 +15,15 @@ module Cloudware
       attr_accessor(*ATTRIBUTES)
       delegate(*DOMAIN_ATTRIBUTES, to: :domain)
 
+      private
+
       def run_create
         provider_machine.create
       end
 
-      private
+      def run_destroy
+        provider_machine.destroy
+      end
 
       def provider_machine
         Providers.select(provider)::Machine.new(self)

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -3,7 +3,23 @@ module Cloudware
   module Models
     class Machine < Application
       ATTRIBUTES = [:name, :type, :flavour, :domain, :role, :priip]
+      DOMAIN_ATTRIBUTES = [:region, :provider]
+
+      def self.delegate_attributes
+        ATTRIBUTES.dup.concat(DOMAIN_ATTRIBUTES.dup)
+      end
+
       attr_accessor(*ATTRIBUTES)
+      delegate(*DOMAIN_ATTRIBUTES, to: :domain)
+
+      def run_create
+      end
+
+      private
+
+      def provider_module
+        Providers.select(provider)
+      end
     end
   end
 end

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -1,0 +1,9 @@
+
+module Cloudware
+  module Models
+    class Machine < Application
+      ATTRIBUTES = [:name, :type, :flavour, :domain, :role, :priip]
+      attr_accessor(*ATTRIBUTES)
+    end
+  end
+end

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -2,7 +2,10 @@
 module Cloudware
   module Models
     class Machine < Application
-      ATTRIBUTES = [:name, :type, :flavour, :domain, :role, :priip]
+      ATTRIBUTES = [
+        :name, :type, :flavour, :domain, :role, :priip, :state, :extip,
+        :instance_id, :id
+      ]
       DOMAIN_ATTRIBUTES = [:region, :provider]
 
       def self.delegate_attributes

--- a/lib/cloudware/providers.rb
+++ b/lib/cloudware/providers.rb
@@ -21,6 +21,10 @@ module Cloudware
       def find_domain(provider, region, name)
         select(provider)::Domains.by_region(region).find_by_name(name)
       end
+
+      def find_machine(provider, region, name)
+        select(provider)::Machines.by_region(region).find_by_name(name)
+      end
     end
   end
 end

--- a/lib/cloudware/providers.rb
+++ b/lib/cloudware/providers.rb
@@ -22,8 +22,16 @@ module Cloudware
         select(provider)::Domains.by_region(region).find_by_name(name)
       end
 
-      def find_machine(provider, region, name)
+      def find_machine(provider, region, name, missing_error: false)
         select(provider)::Machines.by_region(region).find_by_name(name)
+          .tap { |m| raise_if_missing(m, 'machine', name) if missing_error }
+      end
+
+      private
+
+      def raise_if_missing(model, type, name)
+        return if model
+        raise InvalidInput, "Can not find #{type}: #{name}"
       end
     end
   end

--- a/lib/cloudware/providers.rb
+++ b/lib/cloudware/providers.rb
@@ -17,6 +17,10 @@ module Cloudware
           raise InvalidInput, "Unrecognised provider: #{provider}"
         end
       end
+
+      def find_domain(provider, region, name)
+        select(provider)::Domains.by_region(region).find_by_name(name)
+      end
     end
   end
 end

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -49,7 +49,9 @@ module Cloudware
               domain.name = vpc_tags.cloudware_domain
               domain.networkcidr = vpc_tags.cloudware_network_cidr
               domain.prisubnetcidr = vpc_tags.cloudware_pri_subnet_cidr
-              pp subnet = find_subnet(domain.name).original_ec2
+
+              subnet = find_subnet(domain.name)
+              domain.prisubnet_id = subnet.original_ec2.subnet_id
             end
           end
 

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -37,9 +37,7 @@ module Cloudware
           end
 
           def find_subnet(domain_name)
-            subnets.find do |net|
-              net.cloudware_domain == domain_name
-            end
+            subnets.find { |net| net.cloudware_domain == domain_name }
           end
 
           def build_domain(vpc)

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -47,6 +47,7 @@ module Cloudware
               domain.name = vpc_tags.cloudware_domain
               domain.networkcidr = vpc_tags.cloudware_network_cidr
               domain.prisubnetcidr = vpc_tags.cloudware_pri_subnet_cidr
+              domain.network_id = vpc.vpc_id
 
               subnet = find_subnet(domain.name)
               domain.prisubnet_id = subnet.original_ec2.subnet_id

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -28,12 +28,18 @@ module Cloudware
             ).vpcs
           end
 
-          # Ported code
-          # def subnets
-          #   @subnets ||= ec2.describe_subnets(
-          #     filters: [{ name: 'tag-key', values: ['cloudware_id'] }]
-          #   ).subnets
-          # end
+          def subnets
+            @subnets ||= ec2.describe_subnets(
+              filters: [{ name: 'tag-key', values: ['cloudware_id'] }]
+            ).subnets
+          end
+
+          def find_subnet(domain_name)
+            subnets.find do |net|
+              tags = net.tags.map { |t| [t.key, t.value] }.to_h
+              tags['cloudware_domain'] == domain_name
+            end
+          end
 
           def build_domain(vpc)
             args = { provider: 'aws', region: region }
@@ -48,6 +54,7 @@ module Cloudware
                   domain.prisubnetcidr = tag.value
                 end
               end
+              subnet = find_subnet(domain.name)
             end
           end
         end

--- a/lib/cloudware/providers/aws/domains.rb
+++ b/lib/cloudware/providers/aws/domains.rb
@@ -31,13 +31,14 @@ module Cloudware
           def subnets
             @subnets ||= ec2.describe_subnets(
               filters: [{ name: 'tag-key', values: ['cloudware_id'] }]
-            ).subnets
+            ).subnets.map do |net|
+              tags_structs(net.tags).tap { |t| t.original_ec2 = net }
+            end
           end
 
           def find_subnet(domain_name)
             subnets.find do |net|
-              tags = tags_structs(net.tags)
-              tags.cloudware_domain == domain_name
+              net.cloudware_domain == domain_name
             end
           end
 
@@ -48,7 +49,7 @@ module Cloudware
               domain.name = vpc_tags.cloudware_domain
               domain.networkcidr = vpc_tags.cloudware_network_cidr
               domain.prisubnetcidr = vpc_tags.cloudware_pri_subnet_cidr
-              subnet = find_subnet(domain.name)
+              pp subnet = find_subnet(domain.name).original_ec2
             end
           end
 

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -3,6 +3,52 @@ module Cloudware
   module Providers
     module AWS
       class Machine < Base::Machine
+        include DeployAWS
+
+        def create
+          deploy_aws
+        end
+
+        private
+
+        def id
+          @id ||= SecureRandom.uuid
+        end
+
+        def deploy_parameters
+          [
+            {
+              parameter_key: 'cloudwareDomain',
+              parameter_value: domain.name
+            },
+            { parameter_key: 'cloudwareId', parameter_value: id },
+            { parameter_key: 'priIp', parameter_value: priip },
+            { parameter_key: 'vmRole', parameter_value: role },
+            { parameter_key: 'vmType', parameter_value: type },
+            { parameter_key: 'vmName', parameter_value: name },
+            {
+              parameter_key: 'networkId',
+              parameter_value: domain.network_id
+            },
+            {
+              parameter_key: 'priSubnetId',
+              parameter_value: domain.pri_subnet_id
+            },
+            {
+              parameter_key: 'priSubnetCidr',
+              parameter_value: domain.pri_subnet_cidr
+            },
+            { parameter_key: 'vmFlavour', parameter_value: flavour },
+          ]
+        end
+
+        def deploy_template_content
+          path = File.join(
+            Cloudware.config.base_dir,
+            "providers/aws/templates/machine-#{role}.yml"
+          )
+          File.read(path)
+        end
       end
     end
   end

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -11,6 +11,10 @@ module Cloudware
 
         private
 
+        def aws_type
+          machine_mappings[flavour][type]
+        end
+
         def id
           @id ||= SecureRandom.uuid
         end
@@ -24,7 +28,7 @@ module Cloudware
             { parameter_key: 'cloudwareId', parameter_value: id },
             { parameter_key: 'priIp', parameter_value: priip },
             { parameter_key: 'vmRole', parameter_value: role },
-            { parameter_key: 'vmType', parameter_value: type },
+            { parameter_key: 'vmType', parameter_value: aws_type },
             { parameter_key: 'vmName', parameter_value: name },
             {
               parameter_key: 'networkId',
@@ -48,6 +52,13 @@ module Cloudware
             "providers/aws/templates/machine-#{role}.yml"
           )
           File.read(path)
+        end
+
+        def machine_mappings
+          @machine_mappings ||= YAML.load_file(File.join(
+            Cloudware.config.base_dir,
+              "providers/aws/mappings/machine_types.yml"
+          ))
         end
       end
     end

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -32,11 +32,11 @@ module Cloudware
             },
             {
               parameter_key: 'priSubnetId',
-              parameter_value: domain.pri_subnet_id
+              parameter_value: domain.prisubnet_id
             },
             {
               parameter_key: 'priSubnetCidr',
-              parameter_value: domain.pri_subnet_cidr
+              parameter_value: domain.prisubnetcidr
             },
             { parameter_key: 'vmFlavour', parameter_value: flavour },
           ]

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -1,0 +1,9 @@
+
+module Cloudware
+  module Providers
+    module AWS
+      class Machine < Base::Machine
+      end
+    end
+  end
+end

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -12,7 +12,7 @@ module Cloudware
         private
 
         def aws_type
-          machine_mappings[flavour][type]
+          provider_type || machine_mappings[flavour][type]
         end
 
         def id

--- a/lib/cloudware/providers/aws/machines.rb
+++ b/lib/cloudware/providers/aws/machines.rb
@@ -27,7 +27,7 @@ module Cloudware
             Models::Machine.build(
               state: instance.state.name,
               extip: instance.public_ip_address,
-              type: instance.instance_type,
+              provider_type: instance.instance_type,
               instance_id: instance.instance_id,
               domain: domains.find_by_name(tags.cloudware_domain),
               id: tags.cloudware_id,

--- a/lib/cloudware/providers/aws/machines.rb
+++ b/lib/cloudware/providers/aws/machines.rb
@@ -15,7 +15,7 @@ module Cloudware
           end
 
           def models
-            pp instances.map { |i| build_machine(i) }
+            instances.map { |i| build_machine(i) }
           end
 
           private

--- a/lib/cloudware/providers/aws/machines.rb
+++ b/lib/cloudware/providers/aws/machines.rb
@@ -15,11 +15,23 @@ module Cloudware
           end
 
           def models
+            pp instances
           end
 
           private
 
           attr_reader :region, :ec2
+
+          def instances
+            @instances ||= begin
+              ec2.describe_instances(
+                filters: [{ name: 'tag-key', values: ['cloudware_id'] }]
+              ).reservations
+               .map(&:instances)
+               .flatten
+               .reject { |i| i.state.name == 'terminated' }
+            end
+          end
 
           def tags_structs(tags_struct)
             OpenStruct.new(

--- a/lib/cloudware/providers/aws/machines.rb
+++ b/lib/cloudware/providers/aws/machines.rb
@@ -4,7 +4,7 @@
 module Cloudware
   module Providers
     module AWS
-      class Machines < Base::Domains
+      class Machines < Base::Machines
         class Builder
           def initialize(region)
             @region ||= region

--- a/lib/cloudware/providers/aws/machines.rb
+++ b/lib/cloudware/providers/aws/machines.rb
@@ -32,7 +32,7 @@ module Cloudware
               domain: domains.find_by_name(tags.cloudware_domain),
               id: tags.cloudware_id,
               role: tags.cloudware_machine_role,
-              priip: tags.cloudware_pri_subnet_id,
+              priip: tags.cloudware_pri_subnet_ip,
               name: tags.cloudware_machine_name,
               flavour: tags.cloudware_machine_flavour
             )

--- a/lib/cloudware/providers/aws/machines.rb
+++ b/lib/cloudware/providers/aws/machines.rb
@@ -1,0 +1,33 @@
+
+# frozen_string_literal: true
+
+module Cloudware
+  module Providers
+    module AWS
+      class Machines < Base::Domains
+        class Builder
+          def initialize(region)
+            @region ||= region
+            @ec2 = Aws::EC2::Client.new(
+              region: region,
+              credentials: Cloudware.config.credentials.aws
+            )
+          end
+
+          def models
+          end
+
+          private
+
+          attr_reader :region, :ec2
+
+          def tags_structs(tags_struct)
+            OpenStruct.new(
+              tags_struct.map { |t| [t.key, t.value] }.to_h
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudware/providers/base/machine.rb
+++ b/lib/cloudware/providers/base/machine.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Cloudware
+  module Providers
+    module Base
+      class Machine
+        def initialize(machine_model)
+          @machine_model = machine_model
+        end
+
+        def create
+          raise NotImplementedError
+        end
+
+        def destroy
+          raise NotImplementedError
+        end
+
+        private
+
+        attr_reader :machine_model
+
+        delegate(*Models::Machine.delegate_attributes, to: :machine_model)
+      end
+    end
+  end
+end

--- a/lib/cloudware/providers/base/machines.rb
+++ b/lib/cloudware/providers/base/machines.rb
@@ -7,7 +7,7 @@ module Cloudware
       class Machines < Array
         class << self
           def by_region(region)
-            new(models_by_region(region))
+            new(self::Builder.new(region).models)
           end
 
           private

--- a/lib/cloudware/providers/base/machines.rb
+++ b/lib/cloudware/providers/base/machines.rb
@@ -1,0 +1,26 @@
+
+# frozen_string_literal: true
+
+module Cloudware
+  module Providers
+    module Base
+      class Machines < Array
+        class << self
+          def by_region(region)
+            new(models_by_region(region))
+          end
+
+          private
+
+          def models_by_region(_region)
+            raise NotImplementedError
+          end
+        end
+
+        def find_by_name(name)
+          find { |model| model.name == name }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on #71, please merge it first

Refactored `machine list` to be consistent with the other commands. It is essentially a trimmed down version of `list` but for a single machine.

Refactoring the `machine rebuild` command required making a distinction between a `vm-type` (e.g. `compute` and `gpu`) verses a provider type (`c4.xlarge`). Once this was done, the command was simply updated to finding the old machine, destroying it and then creating the model again.