### PR TITLE
Azure Templates

### DIFF
--- a/providers/azure/templates/domain.json
+++ b/providers/azure/templates/domain.json
@@ -2,14 +2,14 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "networkCIDR": {
+    "networkCidr": {
       "type": "string",
       "defaultValue": "10.0.0.0/16",
       "metadata": {
         "description": "Choose the desired network range"
       }
     },
-    "priSubnetCIDR": {
+    "priSubnetCidr": {
       "type": "string",
       "defaultValue": "10.0.1.0/24",
       "metadata": {
@@ -38,22 +38,22 @@
         "cloudware_id": "[parameters('cloudwareId')]",
         "cloudware_domain": "[parameters('cloudwareDomain')]",
         "cloudware_domain_region": "[resourceGroup().location]",
-        "cloudware_network_cidr": "[parameters('networkCIDR')]",
-        "cloudware_pri_subnet_cidr": "[parameters('priSubnetCIDR')]",
+        "cloudware_network_cidr": "[parameters('networkCidr')]",
+        "cloudware_pri_subnet_cidr": "[parameters('priSubnetCidr')]",
         "cloudware_resource_type": "domain"
       },
       "location": "[resourceGroup().location]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('networkCIDR')]"
+            "[parameters('networkCidr')]"
           ]
         },
         "subnets": [
           {
             "name": "pri",
             "properties": {
-              "addressPrefix": "[parameters('priSubnetCIDR')]"
+              "addressPrefix": "[parameters('priSubnetCidr')]"
             }
           }
         ]

--- a/providers/azure/templates/domain0.json
+++ b/providers/azure/templates/domain0.json
@@ -4,14 +4,14 @@
   "parameters": {
     "networkCIDR": {
       "type": "string",
-      "defaultValue": "10.0.0.0/16",
+      "defaultValue": "10.78.100.0/24",
       "metadata": {
         "description": "Choose the desired network range"
       }
     },
     "priSubnetCIDR": {
       "type": "string",
-      "defaultValue": "10.0.1.0/24",
+      "defaultValue": "10.78.100.0/24",
       "metadata": {
         "description": "Choose the desired pri subnet range"
       }
@@ -40,7 +40,7 @@
         "cloudware_domain_region": "[resourceGroup().location]",
         "cloudware_network_cidr": "[parameters('networkCIDR')]",
         "cloudware_pri_subnet_cidr": "[parameters('priSubnetCIDR')]",
-        "cloudware_resource_type": "domain"
+        "cloudware_resource_type": "domaini0"
       },
       "location": "[resourceGroup().location]",
       "properties": {

--- a/providers/azure/templates/domain0.json
+++ b/providers/azure/templates/domain0.json
@@ -2,14 +2,14 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "networkCIDR": {
+    "networkCidr": {
       "type": "string",
       "defaultValue": "10.78.100.0/24",
       "metadata": {
         "description": "Choose the desired network range"
       }
     },
-    "priSubnetCIDR": {
+    "priSubnetCidr": {
       "type": "string",
       "defaultValue": "10.78.100.0/24",
       "metadata": {
@@ -38,22 +38,22 @@
         "cloudware_id": "[parameters('cloudwareId')]",
         "cloudware_domain": "[parameters('cloudwareDomain')]",
         "cloudware_domain_region": "[resourceGroup().location]",
-        "cloudware_network_cidr": "[parameters('networkCIDR')]",
-        "cloudware_pri_subnet_cidr": "[parameters('priSubnetCIDR')]",
+        "cloudware_network_cidr": "[parameters('networkCidr')]",
+        "cloudware_pri_subnet_cidr": "[parameters('priSubnetCidr')]",
         "cloudware_resource_type": "domaini0"
       },
       "location": "[resourceGroup().location]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('networkCIDR')]"
+            "[parameters('networkCidr')]"
           ]
         },
         "subnets": [
           {
             "name": "pri",
             "properties": {
-              "addressPrefix": "[parameters('priSubnetCIDR')]"
+              "addressPrefix": "[parameters('priSubnetCidr')]"
             }
           }
         ]

--- a/providers/azure/templates/domainU.json
+++ b/providers/azure/templates/domainU.json
@@ -4,14 +4,14 @@
   "parameters": {
     "networkCIDR": {
       "type": "string",
-      "defaultValue": "10.0.0.0/16",
+      "defaultValue": "10.100.1.0/24",
       "metadata": {
         "description": "Choose the desired network range"
       }
     },
     "priSubnetCIDR": {
       "type": "string",
-      "defaultValue": "10.0.1.0/24",
+      "defaultValue": "10.100.1.0/24",
       "metadata": {
         "description": "Choose the desired pri subnet range"
       }
@@ -27,6 +27,13 @@
       "metadata": {
         "description": "Cloudware domain"
       }
+    },
+    "clusterIndex": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "Cluster index"
+      }
     }
   },
   "resources": [
@@ -38,22 +45,22 @@
         "cloudware_id": "[parameters('cloudwareId')]",
         "cloudware_domain": "[parameters('cloudwareDomain')]",
         "cloudware_domain_region": "[resourceGroup().location]",
-        "cloudware_network_cidr": "[parameters('networkCIDR')]",
-        "cloudware_pri_subnet_cidr": "[parameters('priSubnetCIDR')]",
-        "cloudware_resource_type": "domain"
+        "cloudware_network_cidr": "[concat('10.100.', parameters('clusterIndex'), '.0/24')]",
+        "cloudware_pri_subnet_cidr": "[concat('10.100.', parameters('clusterIndex'), '.0/24')]",
+        "cloudware_resource_type": "domainiU"
       },
       "location": "[resourceGroup().location]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('networkCIDR')]"
+            "[concat('10.100.', parameters('clusterIndex'), '.0/24')]"
           ]
         },
         "subnets": [
           {
             "name": "pri",
             "properties": {
-              "addressPrefix": "[parameters('priSubnetCIDR')]"
+              "addressPrefix": "[concat('10.100.', parameters('clusterIndex'), '.0/24')]"
             }
           }
         ]

--- a/providers/azure/templates/domainU.json
+++ b/providers/azure/templates/domainU.json
@@ -2,14 +2,14 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "networkCIDR": {
+    "networkCidr": {
       "type": "string",
       "defaultValue": "10.100.1.0/24",
       "metadata": {
         "description": "Choose the desired network range"
       }
     },
-    "priSubnetCIDR": {
+    "priSubnetCidr": {
       "type": "string",
       "defaultValue": "10.100.1.0/24",
       "metadata": {

--- a/providers/azure/templates/machine-gateway.json
+++ b/providers/azure/templates/machine-gateway.json
@@ -16,6 +16,7 @@
 		},
 		"vmName": {
 			"type": "string",
+            "defaultValue": "gateway",
 			"metadata": {
 				"description": "Choose the VM name"
 			}
@@ -34,6 +35,7 @@
 		},
 		"priSubnetIp": {
 			"type": "string",
+            "defaultValue": "10.78.100.10",
 			"metadata": {
 				"description": "Enter the desired pri subnet IP address"
 			}
@@ -41,7 +43,7 @@
 	},
 	"variables": {
 		"adminUsername": "alces",
-		"adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/0R5EvmSrySy2I+8Cx6eOX7cVuYFXx5D0O1x0+OmAZ0Qaj9d7E0Nj4ZcWxdCT03uFl1Ka4tInDlQmMyy0V1/AftpHxBEnB17Pk/lJnDW1YstmAqD0GlFa1CrxUdtHd+jB3LJmdoHsV6fRGpMOgFd+u/4Wces7KAqYFmL5uPG1UTCMgokQ2qboQgEVspXotMvni1iil3kEjyH/eW64Laxmn2Vxls9feZ1o95mPQhJPJcN7MMo1h+jkxyat3bawtpqyV7fXYU0+BO2JHpu/VIEDHtxhlk7RhI0U06XbJu6ZCCUrEX8idIhw4hueQpKwVYplTXssa9JqNlcjouqLj5kd cloudware@alces-software.com",
+		"adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCK8fxlYAcZHfZ9Rhcl0IIcFAleztyMkBF6CxfcaqI6XO9WYhy/sawZXnOHlACjLfx1RuDu+kDvPT/lhxay7yrQt0g1HsTs3xwW6luZuLxPvCS7Zqi0AGqr/LC6OWUKodpNe8ZUPxCWx+JiyaRb9SD+PWqV0WPiZXTmgd9lRYfWuvMl24sNvK8VWWzWSr8q2+1yGNbyzoFC/NUfoMuFEPyb+XV3BIKNyacAM8gep+mrFxadV1ehZConzeoJSFavlJUiU76JMKkbJcfUeXFqTBk/W1mXpmYPw+JUZzsDM2RZD/Ef4LrhyxjtLVLelrIU5j4DN/7lMCsMf3tdfXbJ2+fp aws_ireland",
 		"priInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'pri')]",
 		"azureConfig": {
 			"imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
@@ -69,7 +71,20 @@
 						"priority": 1000,
 						"direction": "Inbound"
 					}
-				}]
+				},
+                {
+                    "name": "inbound-vpn",
+                    "properties": {
+                       "protocol": "TCP",
+                       "sourcePortRange": "*",
+                       "destinationPortRange": "2005",
+                       "sourceAddressPrefix": "*",
+                       "destinationAddressPrefix": "*",
+                       "access": "Allow",
+                       "priority": 1010,
+                       "direction": "Inbound"
+                    }
+                }]
 			}
 		},
 		{
@@ -128,7 +143,7 @@
 				"cloudware_domain": "[parameters('cloudwareDomain')]",
 				"cloudware_id": "[parameters('cloudwareId')]",
 				"cloudware_machine_name": "[parameters('vmName')]",
-				"cloudware_machine_role": "master",
+				"cloudware_machine_role": "gateway",
 				"cloudware_machine_type": "[parameters('vmType')]",
 				"cloudware_machine_flavour": "[parameters('vmFlavour')]",
 				"cloudware_resource_type": "machine",

--- a/providers/azure/templates/machine-login.json
+++ b/providers/azure/templates/machine-login.json
@@ -16,6 +16,7 @@
 		},
 		"vmName": {
 			"type": "string",
+            "defaultValue": "loogin",
 			"metadata": {
 				"description": "Choose the VM name"
 			}
@@ -34,14 +35,22 @@
 		},
 		"priSubnetIp": {
 			"type": "string",
+            "defaultValue": "10.100.1.10",
 			"metadata": {
 				"description": "Enter the desired pri subnet IP address"
 			}
-		}
+		},
+        "clusterIndex": {
+            "type": "int",
+            "defaultValue": 1,
+            "metadata": {
+                "description": "Cluster index"
+            }
+        }
 	},
 	"variables": {
 		"adminUsername": "alces",
-		"adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/0R5EvmSrySy2I+8Cx6eOX7cVuYFXx5D0O1x0+OmAZ0Qaj9d7E0Nj4ZcWxdCT03uFl1Ka4tInDlQmMyy0V1/AftpHxBEnB17Pk/lJnDW1YstmAqD0GlFa1CrxUdtHd+jB3LJmdoHsV6fRGpMOgFd+u/4Wces7KAqYFmL5uPG1UTCMgokQ2qboQgEVspXotMvni1iil3kEjyH/eW64Laxmn2Vxls9feZ1o95mPQhJPJcN7MMo1h+jkxyat3bawtpqyV7fXYU0+BO2JHpu/VIEDHtxhlk7RhI0U06XbJu6ZCCUrEX8idIhw4hueQpKwVYplTXssa9JqNlcjouqLj5kd cloudware@alces-software.com",
+		"adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCK8fxlYAcZHfZ9Rhcl0IIcFAleztyMkBF6CxfcaqI6XO9WYhy/sawZXnOHlACjLfx1RuDu+kDvPT/lhxay7yrQt0g1HsTs3xwW6luZuLxPvCS7Zqi0AGqr/LC6OWUKodpNe8ZUPxCWx+JiyaRb9SD+PWqV0WPiZXTmgd9lRYfWuvMl24sNvK8VWWzWSr8q2+1yGNbyzoFC/NUfoMuFEPyb+XV3BIKNyacAM8gep+mrFxadV1ehZConzeoJSFavlJUiU76JMKkbJcfUeXFqTBk/W1mXpmYPw+JUZzsDM2RZD/Ef4LrhyxjtLVLelrIU5j4DN/7lMCsMf3tdfXbJ2+fp aws_ireland",
 		"priInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'pri')]",
 		"azureConfig": {
 			"imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
@@ -103,7 +112,7 @@
 					"name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-pri')]",
 					"properties": {
 						"privateIPAllocationMethod": "Static",
-						"privateIPAddress": "[parameters('priSubnetIp')]",
+						"privateIPAddress": "[concat('10.100.', parameters('clusterIndex'), '.10')]",
 						"publicIPAddress": {
 							"id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
 						},
@@ -128,11 +137,11 @@
 				"cloudware_domain": "[parameters('cloudwareDomain')]",
 				"cloudware_id": "[parameters('cloudwareId')]",
 				"cloudware_machine_name": "[parameters('vmName')]",
-				"cloudware_machine_role": "master",
+				"cloudware_machine_role": "loogin",
 				"cloudware_machine_type": "[parameters('vmType')]",
 				"cloudware_machine_flavour": "[parameters('vmFlavour')]",
 				"cloudware_resource_type": "machine",
-				"cloudware_pri_ip": "[parameters('priSubnetIp')]"
+				"cloudware_pri_ip": "[concat('10.100.', parameters('clusterIndex'), '.10')]"
 			},
 			"location": "[resourceGroup().location]",
 			"properties": {


### PR DESCRIPTION
This PR addresses Azure templates for flightconnector.

One of the most notable things of this PR is that the Azure template parameter names are now in-line with the ones in AWS templates. Previously, for example, AWS used `networkCidr` and Azure used `networkCIDR`, now both use `networkCidr` so hopefully this allows for some ease of ambiguity between the different cloud provider templates. 

From my testing (via the GUI at portal.azure.com) these templates deploy in much the same way as AWS templates.