### PR TITLE
Fix `machine list` to work with azure

### DIFF
--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -5,6 +5,8 @@ module Cloudware
       class Machine < Base::Machine
         include DeployAWS
 
+        attr_accessor :state
+
         def power_on
           ec2.start_instances(
             instance_ids: [instance_id]

--- a/lib/cloudware/providers/azure/helpers/clients.rb
+++ b/lib/cloudware/providers/azure/helpers/clients.rb
@@ -19,6 +19,13 @@ module Cloudware
             )
           end
           memoize :network
+
+          def compute
+            Azure::Compute::Profiles::Latest::Mgmt::Client.new(
+              Cloudware.config.credentials.azure
+            )
+          end
+          memoize :compute
         end
 
         module Client

--- a/lib/cloudware/providers/azure/helpers/clients.rb
+++ b/lib/cloudware/providers/azure/helpers/clients.rb
@@ -4,13 +4,21 @@ module Cloudware
     module AZURE
       module Helpers
         class AzureClient
+          extend Memoist
+
           def resource
-            @resource ||= begin
-              Azure::Resources::Profiles::Latest::Mgmt::Client.new(
-                Cloudware.config.credentials.azure
-              )
-            end
+            Azure::Resources::Profiles::Latest::Mgmt::Client.new(
+              Cloudware.config.credentials.azure
+            )
           end
+          memoize :resource
+
+          def network
+            Azure::Network::Profiles::Latest::Mgmt::Client.new(
+              Cloudware.config.credentials.azure
+            )
+          end
+          memoize :network
         end
 
         module Client

--- a/lib/cloudware/providers/azure/machine.rb
+++ b/lib/cloudware/providers/azure/machine.rb
@@ -2,9 +2,23 @@ module Cloudware
   module Providers
     module AZURE
       class Machine < Base::Machine
+        STATE_REGEX = /PowerState\//
+
         include Helpers::Deploy
 
+        def state
+          client.compute.virtual_machines.instance_view(
+            resource_group_name, name
+          ).statuses
+           .reverse
+           .find { |s| STATE_REGEX.match?(s.code) }
+           .code
+           .sub(STATE_REGEX, '')
+        end
+
         private
+
+        include Helpers::Client
 
         def resource_group_name
           domain.resource_group.name + '-machine-' + name

--- a/lib/cloudware/providers/azure/machines.rb
+++ b/lib/cloudware/providers/azure/machines.rb
@@ -41,11 +41,12 @@ module Cloudware
 
           def build_machine(resource)
             tags = OpenStruct.new(resource.tags)
+            domain = domains.find do |d|
+              d.resource_group.name == tags.cloudware_domain
+            end
             Machine.build(
+              domain: domain,
               name: tags.cloudware_machine_name,
-              domain: domains.find do |d|
-                d.resource_group.name == tags.cloudware_domain
-              end,
               id: tags.cloudware_id,
               role: tags.cloudware_machine_role,
               priip: tags.cloudware_pri_ip,

--- a/lib/cloudware/providers/azure/machines.rb
+++ b/lib/cloudware/providers/azure/machines.rb
@@ -19,14 +19,14 @@ module Cloudware
 
           private
 
+          include Helpers::Client
+
+          attr_reader :region
+
           def domains
             Domains.by_region(region)
           end
           memoize :domains
-
-          include Helpers::Client
-
-          attr_reader :region
 
           def resources
             client.resource.resources.list.select do |r|
@@ -38,6 +38,11 @@ module Cloudware
             end
           end
           memoize :resources
+
+          def public_ipaddresses
+            client.network.public_ipaddresses.list_all
+          end
+          memoize :public_ipaddresses
 
           def build_machine(resource)
             tags = OpenStruct.new(resource.tags)

--- a/lib/cloudware/providers/azure/machines.rb
+++ b/lib/cloudware/providers/azure/machines.rb
@@ -1,0 +1,60 @@
+
+# frozen_string_literal: true
+
+module Cloudware
+  module Providers
+    module AZURE
+      class Machines < Base::Machines
+        class Builder
+          extend Memoist
+
+          def initialize(region)
+            @region ||= region
+          end
+
+          def models
+            resources.map { |r| build_machine(r) }
+          end
+          memoize :models
+
+          private
+
+          def domains
+            Domains.by_region(region)
+          end
+          memoize :domains
+
+          include Helpers::Client
+
+          attr_reader :region
+
+          def resources
+            client.resource.resources.list.select do |r|
+              next unless r.tags
+              next unless r.tags['cloudware_resource_type'] == 'machine'
+              next unless r.type == 'Microsoft.Compute/virtualMachines'
+              next unless r.location == region
+              true
+            end
+          end
+          memoize :resources
+
+          def build_machine(resource)
+            tags = OpenStruct.new(resource.tags)
+            Machine.build(
+              name: tags.cloudware_machine_name,
+              domain: domains.find do |d|
+                d.resource_group.name == tags.cloudware_domain
+              end,
+              id: tags.cloudware_id,
+              role: tags.cloudware_machine_role,
+              priip: tags.cloudware_pri_ip,
+              provider_type: tags.cloudware_machine_type,
+              flavour: tags.cloudware_machine_flavour
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudware/providers/azure/machines.rb
+++ b/lib/cloudware/providers/azure/machines.rb
@@ -49,15 +49,26 @@ module Cloudware
             domain = domains.find do |d|
               d.resource_group.name == tags.cloudware_domain
             end
+            name = tags.cloudware_machine_name
+            public_ip = find_public_ip(domain, name)
             Machine.build(
               domain: domain,
-              name: tags.cloudware_machine_name,
+              name: name,
               id: tags.cloudware_id,
               role: tags.cloudware_machine_role,
               priip: tags.cloudware_pri_ip,
+              extip: public_ip.ip_address,
               provider_type: tags.cloudware_machine_type,
               flavour: tags.cloudware_machine_flavour
             )
+          end
+
+          def find_public_ip(domain, machine_name)
+            public_ipaddresses.find do |ip|
+              rg_name = domain.resource_group.name
+              next unless ip.tags['cloudware_domain'] == rg_name
+              ip.name == machine_name
+            end
           end
         end
       end

--- a/lib/cloudware/providers/base/machine.rb
+++ b/lib/cloudware/providers/base/machine.rb
@@ -20,6 +20,10 @@ module Cloudware
           raise NotImplementedError
         end
 
+        def provider_type
+          @provider_type ||= machine_mappings[flavour][type]
+        end
+
         private
 
         def assign_machine_id
@@ -34,10 +38,6 @@ module Cloudware
           ))
         end
         memoize :machine_mappings
-
-        def provider_type
-          @provider_type ||= machine_mappings[flavour][type]
-        end
       end
     end
   end

--- a/lib/cloudware/providers/base/machine.rb
+++ b/lib/cloudware/providers/base/machine.rb
@@ -5,7 +5,7 @@ module Cloudware
     module Base
       class Machine < Application
         attr_accessor :name, :type, :flavour, :domain, :role, :priip,
-                      :state, :extip, :instance_id, :id, :cluster_index
+                      :extip, :instance_id, :id, :cluster_index
         attr_writer :provider_type
 
         delegate :region, :provider, to: :domain


### PR DESCRIPTION
This PR implements the `Machines` class in the `AZURE` model. It is based off the `AWS` version using the code from the original `azure.rb` class.

Network calls are cached where they can so they can be used latter. The power status does have to be extracted from the logs on an individual machine basis.