### PR TITLE
Pass the cluster index into Azure domain template

### DIFF
--- a/lib/cloudware/providers/aws/deploy_aws.rb
+++ b/lib/cloudware/providers/aws/deploy_aws.rb
@@ -15,7 +15,7 @@ module Cloudware
           cloud_formation.create_stack(
             stack_name: name,
             template_body: deploy_template_content,
-            parameters: deploy_parameters
+            parameters: convert_deploy_parameters_to_aws_syntax
           )
           cloud_formation.wait_until(:stack_create_complete, stack_name: name)
         end
@@ -25,6 +25,14 @@ module Cloudware
             region: region,
             credentials: Cloudware.config.credentials.aws
           )
+        end
+
+        # This methods allows the parameters to be defined as a hash then
+        # converted to the syntax required by aws
+        def convert_deploy_parameters_to_aws_syntax
+          deploy_parameters.map do |k, v|
+            { parameter_key: k.to_s , parameter_value: v }
+          end
         end
       end
     end

--- a/lib/cloudware/providers/aws/domain.rb
+++ b/lib/cloudware/providers/aws/domain.rb
@@ -25,17 +25,6 @@ module Cloudware
           @id ||= SecureRandom.uuid
         end
 
-        def deploy_parameters
-          {
-            cloudwareDomain: name,
-            cloudwareId: id,
-            networkCidr: networkcidr,
-            priSubnetCidr: prisubnetcidr,
-          }.tap do |p|
-            p.merge(clusterIndex: cluster_index) if cluster_index
-          end
-        end
-
         def deploy_template_content
           path = File.join(
             Cloudware.config.base_dir,

--- a/lib/cloudware/providers/aws/domain.rb
+++ b/lib/cloudware/providers/aws/domain.rb
@@ -26,21 +26,13 @@ module Cloudware
         end
 
         def deploy_parameters
-          [
-            { parameter_key: 'cloudwareDomain', parameter_value: name },
-            { parameter_key: 'cloudwareId', parameter_value: id },
-            { parameter_key: 'networkCidr', parameter_value: networkcidr },
-            {
-              parameter_key: 'priSubnetCidr',
-              parameter_value: prisubnetcidr,
-            },
-          ].tap do |p|
-            if cluster_index
-              p << {
-                parameter_key: 'clusterIndex',
-                parameter_value: cluster_index,
-              }
-            end
+          {
+            cloudwareDomain: name,
+            cloudwareId: id,
+            networkCidr: networkcidr,
+            priSubnetCidr: prisubnetcidr,
+          }.tap do |p|
+            p.merge(clusterIndex: cluster_index) if cluster_index
           end
         end
 

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -33,36 +33,19 @@ module Cloudware
         end
 
         def deploy_parameters
-          [
-            {
-              parameter_key: 'cloudwareDomain',
-              parameter_value: domain.name
-            },
-            { parameter_key: 'cloudwareId', parameter_value: id },
-            { parameter_key: 'priIp', parameter_value: priip },
-            { parameter_key: 'vmRole', parameter_value: role },
-            { parameter_key: 'vmType', parameter_value: provider_type },
-            { parameter_key: 'vmName', parameter_value: name },
-            {
-              parameter_key: 'networkId',
-              parameter_value: domain.network_id
-            },
-            {
-              parameter_key: 'priSubnetId',
-              parameter_value: domain.prisubnet_id
-            },
-            {
-              parameter_key: 'priSubnetCidr',
-              parameter_value: domain.prisubnetcidr
-            },
-            { parameter_key: 'vmFlavour', parameter_value: flavour },
-          ].tap do |p|
-            if cluster_index
-              p << {
-                parameter_key: 'clusterIndex',
-                parameter_value: cluster_index,
-              }
-            end
+          {
+            cloudwareDomain: domain.name,
+            cloudwareId: id,
+            priIp: priip,
+            vmRole: role,
+            vmType: provider_type,
+            vmName: name,
+            networkId: domain.network_id,
+            priSubnetId: domain.prisubnet_id,
+            priSubnetCidr: domain.prisubnetcidr,
+            vmFlavour: flavour,
+          }.tap do |p|
+            p.merge(clusterIndex: cluster_index) if cluster_index
           end
         end
 

--- a/lib/cloudware/providers/azure/domain.rb
+++ b/lib/cloudware/providers/azure/domain.rb
@@ -14,15 +14,6 @@ module Cloudware
 
         include Helpers::Client
 
-        def deployment_parameters
-          {
-            cloudwareDomain: name,
-            cloudwareId: id,
-            networkCIDR: networkcidr,
-            priSubnetCIDR: prisubnetcidr
-          }
-        end
-
         def resource_group_name
           "alces-flightconnector-#{name}"
         end

--- a/lib/cloudware/providers/base/domain.rb
+++ b/lib/cloudware/providers/base/domain.rb
@@ -65,6 +65,17 @@ module Cloudware
           return unless create_domain_already_exists_flag
           errors.add(:domain, "error, '#{name}' already exists")
         end
+
+        def deploy_parameters
+          {
+            cloudwareDomain: name,
+            cloudwareId: id,
+            networkCidr: networkcidr,
+            priSubnetCidr: prisubnetcidr,
+          }.tap do |p|
+            p.merge(clusterIndex: cluster_index) if cluster_index
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Previously the parameter passing was done independently between the `aws` and `azure`. This meant that `aws` deployments received the `cluster_index` but `azure` deployments did not.

To fix this, the `deploy_parameters` need to be standardised between providers and thus must be stored as a `Hash`. The catch is the providers use different syntax for there parameters. Thus a conversion method has been defined for `aws` which takes the `deploy_parameters` hash and puts it into aws syntax.

`Azure` already uses a conversion method so this stop is not required. Also the `azure` templates have been updated to use `*Cidr` parameters instead of the original `*CIDR` tags. This means the parameters for `aws` and `azure` are the same and thus can be defined in `Base::Domain` class.

This process will be replicated for `Machine` in a future PR.