### PR TITLE
Fix building machines without public IP's

### DIFF
--- a/lib/cloudware/commands/machine/info.rb
+++ b/lib/cloudware/commands/machine/info.rb
@@ -18,7 +18,7 @@ module Cloudware
               t.add_row ['Domain name'.bold, m.domain.name]
               t.add_row ['Machine role'.bold, m.role]
               t.add_row ['Pri subnet IP'.bold, m.priip]
-              t.add_row ['External IP'.bold, m.extip]
+              t.add_row ['External IP'.bold, m.extip || 'n/a']
               t.add_row ['Machine state'.bold, m.state]
               t.add_row ['Machine type'.bold, m.provider_type]
               t.add_row ['Machine flavour'.bold, m.flavour]

--- a/lib/cloudware/providers/aws/deploy_aws.rb
+++ b/lib/cloudware/providers/aws/deploy_aws.rb
@@ -15,7 +15,7 @@ module Cloudware
           cloud_formation.create_stack(
             stack_name: name,
             template_body: deploy_template_content,
-            parameters: deploy_parameters
+            parameters: convert_deploy_parameters_to_aws_syntax
           )
           cloud_formation.wait_until(:stack_create_complete, stack_name: name)
         end
@@ -25,6 +25,14 @@ module Cloudware
             region: region,
             credentials: Cloudware.config.credentials.aws
           )
+        end
+
+        # This methods allows the parameters to be defined as a hash then
+        # converted to the syntax required by aws
+        def convert_deploy_parameters_to_aws_syntax
+          deploy_parameters.map do |k, v|
+            { parameter_key: k.to_s , parameter_value: v }
+          end
         end
       end
     end

--- a/lib/cloudware/providers/aws/deploy_aws.rb
+++ b/lib/cloudware/providers/aws/deploy_aws.rb
@@ -15,7 +15,7 @@ module Cloudware
           cloud_formation.create_stack(
             stack_name: name,
             template_body: deploy_template_content,
-            parameters: convert_deploy_parameters_to_aws_syntax
+            parameters: convert_deployment_parameters_to_aws_syntax
           )
           cloud_formation.wait_until(:stack_create_complete, stack_name: name)
         end
@@ -29,8 +29,8 @@ module Cloudware
 
         # This methods allows the parameters to be defined as a hash then
         # converted to the syntax required by aws
-        def convert_deploy_parameters_to_aws_syntax
-          deploy_parameters.map do |k, v|
+        def convert_deployment_parameters_to_aws_syntax
+          deployment_parameters.map do |k, v|
             { parameter_key: k.to_s , parameter_value: v }
           end
         end

--- a/lib/cloudware/providers/aws/domain.rb
+++ b/lib/cloudware/providers/aws/domain.rb
@@ -25,17 +25,6 @@ module Cloudware
           @id ||= SecureRandom.uuid
         end
 
-        def deploy_parameters
-          {
-            cloudwareDomain: name,
-            cloudwareId: id,
-            networkCidr: networkcidr,
-            priSubnetCidr: prisubnetcidr,
-          }.tap do |p|
-            p.merge(clusterIndex: cluster_index) if cluster_index
-          end
-        end
-
         def deploy_template_content
           path = File.join(
             Cloudware.config.base_dir,

--- a/lib/cloudware/providers/aws/domain.rb
+++ b/lib/cloudware/providers/aws/domain.rb
@@ -26,21 +26,13 @@ module Cloudware
         end
 
         def deploy_parameters
-          [
-            { parameter_key: 'cloudwareDomain', parameter_value: name },
-            { parameter_key: 'cloudwareId', parameter_value: id },
-            { parameter_key: 'networkCidr', parameter_value: networkcidr },
-            {
-              parameter_key: 'priSubnetCidr',
-              parameter_value: prisubnetcidr,
-            },
-          ].tap do |p|
-            if cluster_index
-              p << {
-                parameter_key: 'clusterIndex',
-                parameter_value: cluster_index,
-              }
-            end
+          {
+            cloudwareDomain: name,
+            cloudwareId: id,
+            networkCidr: networkcidr,
+            priSubnetCidr: prisubnetcidr,
+          }.tap do |p|
+            p.merge(clusterIndex: cluster_index) if cluster_index
           end
         end
 

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -38,9 +38,7 @@ module Cloudware
             networkId: domain.network_id,
             priSubnetId: domain.prisubnet_id,
             priSubnetCidr: domain.prisubnetcidr
-          ).tap do |p|
-            p.merge(clusterIndex: cluster_index) if cluster_index
-          end
+          )
         end
 
         def deploy_template_content

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -32,7 +32,7 @@ module Cloudware
           )
         end
 
-        def deploy_parameters
+        def deployment_parameters
           super.merge(
             vmRole: role,
             networkId: domain.network_id,

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -33,36 +33,19 @@ module Cloudware
         end
 
         def deploy_parameters
-          [
-            {
-              parameter_key: 'cloudwareDomain',
-              parameter_value: domain.name
-            },
-            { parameter_key: 'cloudwareId', parameter_value: id },
-            { parameter_key: 'priIp', parameter_value: priip },
-            { parameter_key: 'vmRole', parameter_value: role },
-            { parameter_key: 'vmType', parameter_value: provider_type },
-            { parameter_key: 'vmName', parameter_value: name },
-            {
-              parameter_key: 'networkId',
-              parameter_value: domain.network_id
-            },
-            {
-              parameter_key: 'priSubnetId',
-              parameter_value: domain.prisubnet_id
-            },
-            {
-              parameter_key: 'priSubnetCidr',
-              parameter_value: domain.prisubnetcidr
-            },
-            { parameter_key: 'vmFlavour', parameter_value: flavour },
-          ].tap do |p|
-            if cluster_index
-              p << {
-                parameter_key: 'clusterIndex',
-                parameter_value: cluster_index,
-              }
-            end
+          {
+            cloudwareDomain: domain.name,
+            cloudwareId: id,
+            priIp: priip,
+            vmRole: role,
+            vmType: provider_type,
+            vmName: name,
+            networkId: domain.network_id,
+            priSubnetId: domain.prisubnet_id,
+            priSubnetCidr: domain.prisubnetcidr,
+            vmFlavour: flavour,
+          }.tap do |p|
+            p.merge(clusterIndex: cluster_index) if cluster_index
           end
         end
 

--- a/lib/cloudware/providers/aws/machine.rb
+++ b/lib/cloudware/providers/aws/machine.rb
@@ -33,18 +33,12 @@ module Cloudware
         end
 
         def deploy_parameters
-          {
-            cloudwareDomain: domain.name,
-            cloudwareId: id,
-            priIp: priip,
+          super.merge(
             vmRole: role,
-            vmType: provider_type,
-            vmName: name,
             networkId: domain.network_id,
             priSubnetId: domain.prisubnet_id,
-            priSubnetCidr: domain.prisubnetcidr,
-            vmFlavour: flavour,
-          }.tap do |p|
+            priSubnetCidr: domain.prisubnetcidr
+          ).tap do |p|
             p.merge(clusterIndex: cluster_index) if cluster_index
           end
         end

--- a/lib/cloudware/providers/azure/domain.rb
+++ b/lib/cloudware/providers/azure/domain.rb
@@ -14,15 +14,6 @@ module Cloudware
 
         include Helpers::Client
 
-        def deployment_parameters
-          {
-            cloudwareDomain: name,
-            cloudwareId: id,
-            networkCIDR: networkcidr,
-            priSubnetCIDR: prisubnetcidr
-          }
-        end
-
         def resource_group_name
           "alces-flightconnector-#{name}"
         end

--- a/lib/cloudware/providers/azure/machine.rb
+++ b/lib/cloudware/providers/azure/machine.rb
@@ -41,7 +41,7 @@ module Cloudware
             cloudwareId: id,
             vmName: name,
             vmType: provider_type,
-            priSubnetIp: priip,
+            priIp: priip,
             vmFlavour: flavour,
           }
         end

--- a/lib/cloudware/providers/azure/machine.rb
+++ b/lib/cloudware/providers/azure/machine.rb
@@ -35,15 +35,7 @@ module Cloudware
         end
 
         def deployment_parameters
-          {
-            cloudwareDomainGroup: domain.resource_group.name,
-            cloudwareDomain: name,
-            cloudwareId: id,
-            vmName: name,
-            vmType: provider_type,
-            priIp: priip,
-            vmFlavour: flavour,
-          }
+          super.merge(cloudwareDomainGroup: domain.resource_group.name)
         end
 
         def template_path

--- a/lib/cloudware/providers/azure/machine.rb
+++ b/lib/cloudware/providers/azure/machine.rb
@@ -37,6 +37,7 @@ module Cloudware
         def deployment_parameters
           {
             # TODO: Dafaq? Fix this
+            cloudwareDomainGroup: domain.resource_group.name,
             cloudwareDomain: domain.resource_group.name,
             cloudwareId: id,
             vmName: name,

--- a/lib/cloudware/providers/azure/machine.rb
+++ b/lib/cloudware/providers/azure/machine.rb
@@ -36,9 +36,8 @@ module Cloudware
 
         def deployment_parameters
           {
-            # TODO: Dafaq? Fix this
             cloudwareDomainGroup: domain.resource_group.name,
-            cloudwareDomain: domain.resource_group.name,
+            cloudwareDomain: name,
             cloudwareId: id,
             vmName: name,
             vmType: provider_type,

--- a/lib/cloudware/providers/azure/machines.rb
+++ b/lib/cloudware/providers/azure/machines.rb
@@ -57,7 +57,7 @@ module Cloudware
               id: tags.cloudware_id,
               role: tags.cloudware_machine_role,
               priip: tags.cloudware_pri_ip,
-              extip: public_ip.ip_address,
+              extip: public_ip&.ip_address,
               provider_type: tags.cloudware_machine_type,
               flavour: tags.cloudware_machine_flavour
             )

--- a/lib/cloudware/providers/base/domain.rb
+++ b/lib/cloudware/providers/base/domain.rb
@@ -65,6 +65,17 @@ module Cloudware
           return unless create_domain_already_exists_flag
           errors.add(:domain, "error, '#{name}' already exists")
         end
+
+        def deploy_parameters
+          {
+            cloudwareDomain: name,
+            cloudwareId: id,
+            networkCidr: networkcidr,
+            priSubnetCidr: prisubnetcidr,
+          }.tap do |p|
+            p.merge(clusterIndex: cluster_index) if cluster_index
+          end
+        end
       end
     end
   end

--- a/lib/cloudware/providers/base/domain.rb
+++ b/lib/cloudware/providers/base/domain.rb
@@ -66,7 +66,7 @@ module Cloudware
           errors.add(:domain, "error, '#{name}' already exists")
         end
 
-        def deploy_parameters
+        def deployment_parameters
           {
             cloudwareDomain: name,
             cloudwareId: id,

--- a/lib/cloudware/providers/base/machine.rb
+++ b/lib/cloudware/providers/base/machine.rb
@@ -37,6 +37,18 @@ module Cloudware
           ))
         end
         memoize :machine_mappings
+
+        # Base deploy parameters that all inherited classes should use
+        def deploy_parameters
+          {
+            cloudwareDomain: name,
+            cloudwareId: id,
+            vmName: name,
+            vmType: provider_type,
+            priIp: priip,
+            vmFlavour: flavour,
+          }
+        end
       end
     end
   end

--- a/lib/cloudware/providers/base/machine.rb
+++ b/lib/cloudware/providers/base/machine.rb
@@ -47,7 +47,9 @@ module Cloudware
             vmType: provider_type,
             priIp: priip,
             vmFlavour: flavour,
-          }
+          }.tap do |p|
+            p.merge(clusterIndex: cluster_index) if cluster_index
+          end
         end
       end
     end

--- a/lib/cloudware/providers/base/machine.rb
+++ b/lib/cloudware/providers/base/machine.rb
@@ -39,7 +39,7 @@ module Cloudware
         memoize :machine_mappings
 
         # Base deploy parameters that all inherited classes should use
-        def deploy_parameters
+        def deployment_parameters
           {
             cloudwareDomain: name,
             cloudwareId: id,

--- a/providers/azure/templates/machine-compute.json
+++ b/providers/azure/templates/machine-compute.json
@@ -1,45 +1,45 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"cloudwareDomainGroup": {
-			"type": "string",
-			"metadata": {
-				"description": "Enter the Cloudware domain name"
-			}
-		},
-		"cloudwareId": {
-			"type": "string",
-			"metadata": {
-				"description": "Enter the Cloudware ID"
-			}
-		},
-		"vmName": {
-			"type": "string",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "cloudwareDomainGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "Enter the Cloudware domain name"
+      }
+    },
+    "cloudwareId": {
+      "type": "string",
+      "metadata": {
+        "description": "Enter the Cloudware ID"
+      }
+    },
+    "vmName": {
+      "type": "string",
             "defaultValue": "loogin",
-			"metadata": {
-				"description": "Choose the VM name"
-			}
-		},
-		"vmType": {
-			"type": "string",
-			"metadata": {
-				"description": "Choose the VM size to launch"
-			}
-		},
-		"vmFlavour": {
-			"type": "string",
-			"metadata": {
-				"description": "Choose the VM flavour"
-			}
-		},
-		"priSubnetIp": {
-			"type": "string",
+      "metadata": {
+        "description": "Choose the VM name"
+      }
+    },
+    "vmType": {
+      "type": "string",
+      "metadata": {
+        "description": "Choose the VM size to launch"
+      }
+    },
+    "vmFlavour": {
+      "type": "string",
+      "metadata": {
+        "description": "Choose the VM flavour"
+      }
+    },
+    "priSubnetIp": {
+      "type": "string",
             "defaultValue": "10.100.1.10",
-			"metadata": {
-				"description": "Enter the desired pri subnet IP address"
-			}
-		},
+      "metadata": {
+        "description": "Enter the desired pri subnet IP address"
+      }
+    },
         "clusterIndex": {
             "type": "int",
             "defaultValue": 1,
@@ -47,130 +47,130 @@
                 "description": "Cluster index"
             }
         }
-	},
-	"variables": {
-		"adminUsername": "alces",
-		"adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCK8fxlYAcZHfZ9Rhcl0IIcFAleztyMkBF6CxfcaqI6XO9WYhy/sawZXnOHlACjLfx1RuDu+kDvPT/lhxay7yrQt0g1HsTs3xwW6luZuLxPvCS7Zqi0AGqr/LC6OWUKodpNe8ZUPxCWx+JiyaRb9SD+PWqV0WPiZXTmgd9lRYfWuvMl24sNvK8VWWzWSr8q2+1yGNbyzoFC/NUfoMuFEPyb+XV3BIKNyacAM8gep+mrFxadV1ehZConzeoJSFavlJUiU76JMKkbJcfUeXFqTBk/W1mXpmYPw+JUZzsDM2RZD/Ef4LrhyxjtLVLelrIU5j4DN/7lMCsMf3tdfXbJ2+fp aws_ireland",
-		"priInterfaceName": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), 'pri')]",
-		"azureConfig": {
-			"imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
-		}
-	},
-	"resources": [{
-			"type": "Microsoft.Network/networkSecurityGroups",
-			"name": "[parameters('vmName')]",
-			"apiVersion": "2017-03-01",
-			"tags": {
-				"cloudware_domain": "[parameters('cloudwareDomainGroup')]",
-				"cloudware_machine_name": "[parameters('vmName')]"
-			},
-			"location": "[resourceGroup().location]",
-			"properties": {
-				"securityRules": [{
-					"name": "inbound-ssh",
-					"properties": {
-						"protocol": "TCP",
-						"sourcePortRange": "*",
-						"destinationPortRange": "22",
-						"sourceAddressPrefix": "*",
-						"destinationAddressPrefix": "*",
-						"access": "Allow",
-						"priority": 1000,
-						"direction": "Inbound"
-					}
-				}]
-			}
-		},
-		{
-			"type": "Microsoft.Network/networkInterfaces",
-			"name": "[variables('priInterfaceName')]",
-			"apiVersion": "2017-03-01",
-			"tags": {
-				"cloudware_domain": "[parameters('cloudwareDomainGroup')]",
-				"cloudware_machine_name": "[parameters('vmName')]"
-			},
-			"location": "[resourceGroup().location]",
-			"properties": {
-				"ipConfigurations": [{
-					"name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
-					"properties": {
-						"privateIPAllocationMethod": "Static",
-						"privateIPAddress": "[parameters('priSubnetIp')]",
-						"publicIPAddress": {
-							"id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
-						},
-						"subnet": {
-							"id": "[resourceId(parameters('cloudwareDomainGroup'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
-						}
-					}
-				}],
-				"networkSecurityGroup": {
-					"id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('vmName'))]"
-				}
-			},
-			"dependsOn": [
-				"[resourceId('Microsoft.Network/networkSecurityGroups', parameters('vmName'))]"
-			]
-		},
-		{
-			"type": "Microsoft.Compute/virtualMachines",
-			"name": "[parameters('vmName')]",
-			"apiVersion": "2016-04-30-preview",
-			"tags": {
-				"cloudware_domain": "[parameters('cloudwareDomainGroup')]",
-				"cloudware_id": "[parameters('cloudwareId')]",
-				"cloudware_machine_name": "[parameters('vmName')]",
-				"cloudware_machine_role": "loogin",
-				"cloudware_machine_type": "[parameters('vmType')]",
-				"cloudware_machine_flavour": "[parameters('vmFlavour')]",
-				"cloudware_resource_type": "machine",
-				"cloudware_pri_ip": "[parameters('priSubnetIp')]"
-			},
-			"location": "[resourceGroup().location]",
-			"properties": {
-				"hardwareProfile": {
-					"vmSize": "[parameters('vmType')]"
-				},
-				"storageProfile": {
-					"imageReference": {
+  },
+  "variables": {
+    "adminUsername": "alces",
+    "adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCK8fxlYAcZHfZ9Rhcl0IIcFAleztyMkBF6CxfcaqI6XO9WYhy/sawZXnOHlACjLfx1RuDu+kDvPT/lhxay7yrQt0g1HsTs3xwW6luZuLxPvCS7Zqi0AGqr/LC6OWUKodpNe8ZUPxCWx+JiyaRb9SD+PWqV0WPiZXTmgd9lRYfWuvMl24sNvK8VWWzWSr8q2+1yGNbyzoFC/NUfoMuFEPyb+XV3BIKNyacAM8gep+mrFxadV1ehZConzeoJSFavlJUiU76JMKkbJcfUeXFqTBk/W1mXpmYPw+JUZzsDM2RZD/Ef4LrhyxjtLVLelrIU5j4DN/7lMCsMf3tdfXbJ2+fp aws_ireland",
+    "priInterfaceName": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), 'pri')]",
+    "azureConfig": {
+      "imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
+    }
+  },
+  "resources": [{
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('vmName')]",
+      "apiVersion": "2017-03-01",
+      "tags": {
+        "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
+        "cloudware_machine_name": "[parameters('vmName')]"
+      },
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [{
+          "name": "inbound-ssh",
+          "properties": {
+            "protocol": "TCP",
+            "sourcePortRange": "*",
+            "destinationPortRange": "22",
+            "sourceAddressPrefix": "*",
+            "destinationAddressPrefix": "*",
+            "access": "Allow",
+            "priority": 1000,
+            "direction": "Inbound"
+          }
+        }]
+      }
+    },
+    {
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('priInterfaceName')]",
+      "apiVersion": "2017-03-01",
+      "tags": {
+        "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
+        "cloudware_machine_name": "[parameters('vmName')]"
+      },
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "ipConfigurations": [{
+          "name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
+          "properties": {
+            "privateIPAllocationMethod": "Static",
+            "privateIPAddress": "[parameters('priSubnetIp')]",
+            "publicIPAddress": {
+              "id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
+            },
+            "subnet": {
+              "id": "[resourceId(parameters('cloudwareDomainGroup'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
+            }
+          }
+        }],
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('vmName'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('vmName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "apiVersion": "2016-04-30-preview",
+      "tags": {
+        "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
+        "cloudware_id": "[parameters('cloudwareId')]",
+        "cloudware_machine_name": "[parameters('vmName')]",
+        "cloudware_machine_role": "loogin",
+        "cloudware_machine_type": "[parameters('vmType')]",
+        "cloudware_machine_flavour": "[parameters('vmFlavour')]",
+        "cloudware_resource_type": "machine",
+        "cloudware_pri_ip": "[parameters('priSubnetIp')]"
+      },
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmType')]"
+        },
+        "storageProfile": {
+          "imageReference": {
             "publisher": "OpenLogic",
             "offer": "CentOS",
             "sku": "7.3",
             "version": "latest"
-					},
-					"osDisk": {
-						"createOption": "fromImage",
-						"managedDisk": {
-							"storageAccountType": "Premium_LRS"
-						}
-					}
-				},
-				"osProfile": {
-					"computerName": "[concat(parameters('vmName'), '.pri.', '.alces.network')]",
-					"adminUsername": "[variables('adminUsername')]",
-					"linuxConfiguration": {
-						"disablePasswordAuthentication": true,
-						"ssh": {
-							"publicKeys": [{
-								"path": "[concat ('/home/', variables('adminUsername'), '/.ssh/authorized_keys')]",
-								"keyData": "[variables('adminPublicKey')]"
-							}]
-						}
-					}
-				},
-				"networkProfile": {
-					"networkInterfaces": [{
-							"id": "[resourceId('Microsoft.Network/networkInterfaces', variables('priInterfaceName'))]",
-							"properties": {
-								"primary": true
-							}
-						}
-					]
-				}
-			},
-			"dependsOn": [
-				"[resourceId('Microsoft.Network/networkInterfaces', variables('priInterfaceName'))]"
-			]
-		}
-	]
+          },
+          "osDisk": {
+            "createOption": "fromImage",
+            "managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            }
+          }
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('vmName'), '.pri.', '.alces.network')]",
+          "adminUsername": "[variables('adminUsername')]",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+              "publicKeys": [{
+                "path": "[concat ('/home/', variables('adminUsername'), '/.ssh/authorized_keys')]",
+                "keyData": "[variables('adminPublicKey')]"
+              }]
+            }
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [{
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('priInterfaceName'))]",
+              "properties": {
+                "primary": true
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('priInterfaceName'))]"
+      ]
+    }
+  ]
 }

--- a/providers/azure/templates/machine-compute.json
+++ b/providers/azure/templates/machine-compute.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 	"contentVersion": "1.0.0.0",
 	"parameters": {
-		"cloudwareDomain": {
+		"cloudwareDomainGroup": {
 			"type": "string",
 			"metadata": {
 				"description": "Enter the Cloudware domain name"
@@ -51,7 +51,7 @@
 	"variables": {
 		"adminUsername": "alces",
 		"adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCK8fxlYAcZHfZ9Rhcl0IIcFAleztyMkBF6CxfcaqI6XO9WYhy/sawZXnOHlACjLfx1RuDu+kDvPT/lhxay7yrQt0g1HsTs3xwW6luZuLxPvCS7Zqi0AGqr/LC6OWUKodpNe8ZUPxCWx+JiyaRb9SD+PWqV0WPiZXTmgd9lRYfWuvMl24sNvK8VWWzWSr8q2+1yGNbyzoFC/NUfoMuFEPyb+XV3BIKNyacAM8gep+mrFxadV1ehZConzeoJSFavlJUiU76JMKkbJcfUeXFqTBk/W1mXpmYPw+JUZzsDM2RZD/Ef4LrhyxjtLVLelrIU5j4DN/7lMCsMf3tdfXbJ2+fp aws_ireland",
-		"priInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'pri')]",
+		"priInterfaceName": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), 'pri')]",
 		"azureConfig": {
 			"imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
 		}
@@ -61,7 +61,7 @@
 			"name": "[parameters('vmName')]",
 			"apiVersion": "2017-03-01",
 			"tags": {
-				"cloudware_domain": "[parameters('cloudwareDomain')]",
+				"cloudware_domain": "[parameters('cloudwareDomainGroup')]",
 				"cloudware_machine_name": "[parameters('vmName')]"
 			},
 			"location": "[resourceGroup().location]",
@@ -86,13 +86,13 @@
 			"name": "[variables('priInterfaceName')]",
 			"apiVersion": "2017-03-01",
 			"tags": {
-				"cloudware_domain": "[parameters('cloudwareDomain')]",
+				"cloudware_domain": "[parameters('cloudwareDomainGroup')]",
 				"cloudware_machine_name": "[parameters('vmName')]"
 			},
 			"location": "[resourceGroup().location]",
 			"properties": {
 				"ipConfigurations": [{
-					"name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-pri')]",
+					"name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
 					"properties": {
 						"privateIPAllocationMethod": "Static",
 						"privateIPAddress": "[parameters('priSubnetIp')]",
@@ -100,7 +100,7 @@
 							"id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
 						},
 						"subnet": {
-							"id": "[resourceId(parameters('cloudwareDomain'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
+							"id": "[resourceId(parameters('cloudwareDomainGroup'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
 						}
 					}
 				}],
@@ -117,7 +117,7 @@
 			"name": "[parameters('vmName')]",
 			"apiVersion": "2016-04-30-preview",
 			"tags": {
-				"cloudware_domain": "[parameters('cloudwareDomain')]",
+				"cloudware_domain": "[parameters('cloudwareDomainGroup')]",
 				"cloudware_id": "[parameters('cloudwareId')]",
 				"cloudware_machine_name": "[parameters('vmName')]",
 				"cloudware_machine_role": "loogin",

--- a/providers/azure/templates/machine-compute.json
+++ b/providers/azure/templates/machine-compute.json
@@ -102,9 +102,6 @@
           "properties": {
             "privateIPAllocationMethod": "Static",
             "privateIPAddress": "[parameters('priIp')]",
-            "publicIPAddress": {
-              "id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
-            },
             "subnet": {
               "id": "[resourceId(parameters('cloudwareDomainGroup'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
             }

--- a/providers/azure/templates/machine-compute.json
+++ b/providers/azure/templates/machine-compute.json
@@ -39,7 +39,7 @@
         "description": "Choose the VM flavour"
       }
     },
-    "priSubnetIp": {
+    "priIp": {
       "type": "string",
             "defaultValue": "10.100.1.10",
       "metadata": {
@@ -101,7 +101,7 @@
           "name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
           "properties": {
             "privateIPAllocationMethod": "Static",
-            "privateIPAddress": "[parameters('priSubnetIp')]",
+            "privateIPAddress": "[parameters('priIp')]",
             "publicIPAddress": {
               "id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
             },
@@ -130,7 +130,7 @@
         "cloudware_machine_type": "[parameters('vmType')]",
         "cloudware_machine_flavour": "[parameters('vmFlavour')]",
         "cloudware_resource_type": "machine",
-        "cloudware_pri_ip": "[parameters('priSubnetIp')]"
+        "cloudware_pri_ip": "[parameters('priIp')]"
       },
       "location": "[resourceGroup().location]",
       "properties": {

--- a/providers/azure/templates/machine-compute.json
+++ b/providers/azure/templates/machine-compute.json
@@ -152,7 +152,7 @@
           }
         },
         "osProfile": {
-          "computerName": "[concat(parameters('vmName'), '.pri.', '.alces.network')]",
+          "computerName": "[concat(parameters('vmName'), '.pri.', parameters('cloudwareDomain'), '.alces.network')]",
           "adminUsername": "[variables('adminUsername')]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": true,

--- a/providers/azure/templates/machine-compute.json
+++ b/providers/azure/templates/machine-compute.json
@@ -5,6 +5,12 @@
     "cloudwareDomainGroup": {
       "type": "string",
       "metadata": {
+        "description": "Enter the Cloudware domain resource group name"
+      }
+    },
+    "cloudwareDomain": {
+      "type": "string",
+      "metadata": {
         "description": "Enter the Cloudware domain name"
       }
     },

--- a/providers/azure/templates/machine-gateway.json
+++ b/providers/azure/templates/machine-gateway.json
@@ -175,7 +175,7 @@
         }
       },
       "osProfile": {
-        "computerName": "[concat(parameters('vmName'), '.pri.', '.alces.network')]",
+        "computerName": "[concat(parameters('vmName'), '.pri.', parameters('cloudwareDomain'), '.alces.network')]",
         "adminUsername": "[variables('adminUsername')]",
         "linuxConfiguration": {
           "disablePasswordAuthentication": true,

--- a/providers/azure/templates/machine-gateway.json
+++ b/providers/azure/templates/machine-gateway.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "cloudwareDomain": {
+    "cloudwareDomainGroup": {
       "type": "string",
       "metadata": {
         "description": "Enter the Cloudware domain name"
@@ -44,7 +44,7 @@
   "variables": {
     "adminUsername": "alces",
     "adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCK8fxlYAcZHfZ9Rhcl0IIcFAleztyMkBF6CxfcaqI6XO9WYhy/sawZXnOHlACjLfx1RuDu+kDvPT/lhxay7yrQt0g1HsTs3xwW6luZuLxPvCS7Zqi0AGqr/LC6OWUKodpNe8ZUPxCWx+JiyaRb9SD+PWqV0WPiZXTmgd9lRYfWuvMl24sNvK8VWWzWSr8q2+1yGNbyzoFC/NUfoMuFEPyb+XV3BIKNyacAM8gep+mrFxadV1ehZConzeoJSFavlJUiU76JMKkbJcfUeXFqTBk/W1mXpmYPw+JUZzsDM2RZD/Ef4LrhyxjtLVLelrIU5j4DN/7lMCsMf3tdfXbJ2+fp aws_ireland",
-    "priInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'pri')]",
+    "priInterfaceName": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), 'pri')]",
     "azureConfig": {
       "imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
     }
@@ -54,7 +54,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
@@ -92,7 +92,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
@@ -100,7 +100,7 @@
       "publicIPAllocationMethod": "Static",
       "idleTimeoutInMinutes": 30,
       "dnsSettings": {
-        "domainNameLabel": "[concat(parameters('cloudwareDomain'), '-', parameters('vmName'))]"
+        "domainNameLabel": "[concat(parameters('cloudwareDomainGroup'), '-', parameters('vmName'))]"
       }
     }
   },
@@ -109,13 +109,13 @@
     "name": "[variables('priInterfaceName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
     "properties": {
       "ipConfigurations": [{
-        "name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-pri')]",
+        "name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
         "properties": {
           "privateIPAllocationMethod": "Static",
           "privateIPAddress": "[parameters('priSubnetIp')]",
@@ -123,7 +123,7 @@
             "id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
           },
           "subnet": {
-            "id": "[resourceId(parameters('cloudwareDomain'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
+            "id": "[resourceId(parameters('cloudwareDomainGroup'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
           }
         }
       }],
@@ -140,7 +140,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2016-04-30-preview",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_id": "[parameters('cloudwareId')]",
       "cloudware_machine_name": "[parameters('vmName')]",
       "cloudware_machine_role": "gateway",

--- a/providers/azure/templates/machine-gateway.json
+++ b/providers/azure/templates/machine-gateway.json
@@ -5,6 +5,12 @@
     "cloudwareDomainGroup": {
       "type": "string",
       "metadata": {
+        "description": "Enter the Cloudware domain resource group name"
+      }
+    },
+    "cloudwareDomain": {
+      "type": "string",
+      "metadata": {
         "description": "Enter the Cloudware domain name"
       }
     },

--- a/providers/azure/templates/machine-gateway.json
+++ b/providers/azure/templates/machine-gateway.json
@@ -39,7 +39,7 @@
         "description": "Choose the VM flavour"
       }
     },
-    "priSubnetIp": {
+    "priIp": {
       "type": "string",
       "defaultValue": "10.78.100.10",
       "metadata": {
@@ -124,7 +124,7 @@
         "name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
         "properties": {
           "privateIPAllocationMethod": "Static",
-          "privateIPAddress": "[parameters('priSubnetIp')]",
+          "privateIPAddress": "[parameters('priIp')]",
           "publicIPAddress": {
             "id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
           },
@@ -153,7 +153,7 @@
       "cloudware_machine_type": "[parameters('vmType')]",
       "cloudware_machine_flavour": "[parameters('vmFlavour')]",
       "cloudware_resource_type": "machine",
-      "cloudware_pri_ip": "[parameters('priSubnetIp')]"
+      "cloudware_pri_ip": "[parameters('priIp')]"
     },
     "location": "[resourceGroup().location]",
     "properties": {

--- a/providers/azure/templates/machine-login.json
+++ b/providers/azure/templates/machine-login.json
@@ -169,7 +169,7 @@
         }
       },
       "osProfile": {
-        "computerName": "[concat(parameters('vmName'), '.pri.', '.alces.network')]",
+        "computerName": "[concat(parameters('vmName'), '.pri.', parameters('cloudwareDomain'), '.alces.network')]",
         "adminUsername": "[variables('adminUsername')]",
         "linuxConfiguration": {
           "disablePasswordAuthentication": true,

--- a/providers/azure/templates/machine-login.json
+++ b/providers/azure/templates/machine-login.json
@@ -39,7 +39,7 @@
         "description": "Choose the VM flavour"
       }
     },
-    "priSubnetIp": {
+    "priIp": {
       "type": "string",
       "defaultValue": "10.100.1.10",
       "metadata": {

--- a/providers/azure/templates/machine-login.json
+++ b/providers/azure/templates/machine-login.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "cloudwareDomain": {
+    "cloudwareDomainGroup": {
       "type": "string",
       "metadata": {
         "description": "Enter the Cloudware domain name"
@@ -51,7 +51,7 @@
   "variables": {
     "adminUsername": "alces",
     "adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCK8fxlYAcZHfZ9Rhcl0IIcFAleztyMkBF6CxfcaqI6XO9WYhy/sawZXnOHlACjLfx1RuDu+kDvPT/lhxay7yrQt0g1HsTs3xwW6luZuLxPvCS7Zqi0AGqr/LC6OWUKodpNe8ZUPxCWx+JiyaRb9SD+PWqV0WPiZXTmgd9lRYfWuvMl24sNvK8VWWzWSr8q2+1yGNbyzoFC/NUfoMuFEPyb+XV3BIKNyacAM8gep+mrFxadV1ehZConzeoJSFavlJUiU76JMKkbJcfUeXFqTBk/W1mXpmYPw+JUZzsDM2RZD/Ef4LrhyxjtLVLelrIU5j4DN/7lMCsMf3tdfXbJ2+fp aws_ireland",
-    "priInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'pri')]",
+    "priInterfaceName": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), 'pri')]",
     "azureConfig": {
       "imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
     }
@@ -61,7 +61,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
@@ -86,7 +86,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
@@ -94,7 +94,7 @@
       "publicIPAllocationMethod": "Static",
       "idleTimeoutInMinutes": 30,
       "dnsSettings": {
-        "domainNameLabel": "[concat(parameters('cloudwareDomain'), '-', parameters('vmName'))]"
+        "domainNameLabel": "[concat(parameters('cloudwareDomainGroup'), '-', parameters('vmName'))]"
       }
     }
   },
@@ -103,13 +103,13 @@
     "name": "[variables('priInterfaceName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
     "properties": {
       "ipConfigurations": [{
-        "name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-pri')]",
+        "name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
         "properties": {
           "privateIPAllocationMethod": "Static",
           "privateIPAddress": "[concat('10.100.', parameters('clusterIndex'), '.10')]",
@@ -117,7 +117,7 @@
             "id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
           },
           "subnet": {
-            "id": "[resourceId(parameters('cloudwareDomain'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
+            "id": "[resourceId(parameters('cloudwareDomainGroup'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
           }
         }
       }],
@@ -134,7 +134,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2016-04-30-preview",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_id": "[parameters('cloudwareId')]",
       "cloudware_machine_name": "[parameters('vmName')]",
       "cloudware_machine_role": "loogin",

--- a/providers/azure/templates/machine-login.json
+++ b/providers/azure/templates/machine-login.json
@@ -5,6 +5,12 @@
     "cloudwareDomainGroup": {
       "type": "string",
       "metadata": {
+        "description": "Enter the Cloudware domain resource group name"
+      }
+    },
+    "cloudwareDomain": {
+      "type": "string",
+      "metadata": {
         "description": "Enter the Cloudware domain name"
       }
     },

--- a/providers/azure/templates/machine-master.json
+++ b/providers/azure/templates/machine-master.json
@@ -38,7 +38,7 @@
         "description": "Choose the VM flavour"
       }
     },
-    "priSubnetIp": {
+    "priIp": {
       "type": "string",
       "metadata": {
         "description": "Enter the desired pri subnet IP address"
@@ -109,7 +109,7 @@
         "name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
         "properties": {
           "privateIPAllocationMethod": "Static",
-          "privateIPAddress": "[parameters('priSubnetIp')]",
+          "privateIPAddress": "[parameters('priIp')]",
           "publicIPAddress": {
             "id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
           },
@@ -138,7 +138,7 @@
       "cloudware_machine_type": "[parameters('vmType')]",
       "cloudware_machine_flavour": "[parameters('vmFlavour')]",
       "cloudware_resource_type": "machine",
-      "cloudware_pri_ip": "[parameters('priSubnetIp')]"
+      "cloudware_pri_ip": "[parameters('priIp')]"
     },
     "location": "[resourceGroup().location]",
     "properties": {

--- a/providers/azure/templates/machine-master.json
+++ b/providers/azure/templates/machine-master.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "cloudwareDomain": {
+    "cloudwareDomainGroup": {
       "type": "string",
       "metadata": {
         "description": "Enter the Cloudware domain name"
@@ -42,7 +42,7 @@
   "variables": {
     "adminUsername": "alces",
     "adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/0R5EvmSrySy2I+8Cx6eOX7cVuYFXx5D0O1x0+OmAZ0Qaj9d7E0Nj4ZcWxdCT03uFl1Ka4tInDlQmMyy0V1/AftpHxBEnB17Pk/lJnDW1YstmAqD0GlFa1CrxUdtHd+jB3LJmdoHsV6fRGpMOgFd+u/4Wces7KAqYFmL5uPG1UTCMgokQ2qboQgEVspXotMvni1iil3kEjyH/eW64Laxmn2Vxls9feZ1o95mPQhJPJcN7MMo1h+jkxyat3bawtpqyV7fXYU0+BO2JHpu/VIEDHtxhlk7RhI0U06XbJu6ZCCUrEX8idIhw4hueQpKwVYplTXssa9JqNlcjouqLj5kd cloudware@alces-software.com",
-    "priInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'pri')]",
+    "priInterfaceName": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), 'pri')]",
     "azureConfig": {
       "imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
     }
@@ -52,7 +52,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
@@ -77,7 +77,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
@@ -85,7 +85,7 @@
       "publicIPAllocationMethod": "Static",
       "idleTimeoutInMinutes": 30,
       "dnsSettings": {
-        "domainNameLabel": "[concat(parameters('cloudwareDomain'), '-', parameters('vmName'))]"
+        "domainNameLabel": "[concat(parameters('cloudwareDomainGroup'), '-', parameters('vmName'))]"
       }
     }
   },
@@ -94,13 +94,13 @@
     "name": "[variables('priInterfaceName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
     "properties": {
       "ipConfigurations": [{
-        "name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-pri')]",
+        "name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
         "properties": {
           "privateIPAllocationMethod": "Static",
           "privateIPAddress": "[parameters('priSubnetIp')]",
@@ -108,7 +108,7 @@
             "id": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('vmName'))]"
           },
           "subnet": {
-            "id": "[resourceId(parameters('cloudwareDomain'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
+            "id": "[resourceId(parameters('cloudwareDomainGroup'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
           }
         }
       }],
@@ -125,7 +125,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2016-04-30-preview",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_id": "[parameters('cloudwareId')]",
       "cloudware_machine_name": "[parameters('vmName')]",
       "cloudware_machine_role": "master",

--- a/providers/azure/templates/machine-master.json
+++ b/providers/azure/templates/machine-master.json
@@ -160,7 +160,7 @@
         }
       },
       "osProfile": {
-        "computerName": "[concat(parameters('vmName'), '.pri.', '.alces.network')]",
+        "computerName": "[concat(parameters('vmName'), '.pri.', parameters('cloudwareDomain'), '.alces.network')]",
         "adminUsername": "[variables('adminUsername')]",
         "linuxConfiguration": {
           "disablePasswordAuthentication": true,

--- a/providers/azure/templates/machine-master.json
+++ b/providers/azure/templates/machine-master.json
@@ -5,6 +5,12 @@
     "cloudwareDomainGroup": {
       "type": "string",
       "metadata": {
+        "description": "Enter the Cloudware domain resource group name"
+      }
+    },
+    "cloudwareDomain": {
+      "type": "string",
+      "metadata": {
         "description": "Enter the Cloudware domain name"
       }
     },

--- a/providers/azure/templates/machine-slave.json
+++ b/providers/azure/templates/machine-slave.json
@@ -137,7 +137,7 @@
         }
       },
       "osProfile": {
-        "computerName": "[concat(parameters('vmName'), '.pri.', '.alces.network')]",
+        "computerName": "[concat(parameters('vmName'), '.pri.', parameters('cloudwareDomain'), '.alces.network')]",
         "adminUsername": "[variables('adminUsername')]",
         "linuxConfiguration": {
           "disablePasswordAuthentication": true,

--- a/providers/azure/templates/machine-slave.json
+++ b/providers/azure/templates/machine-slave.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "cloudwareDomain": {
+    "cloudwareDomainGroup": {
       "type": "string",
       "metadata": {
         "description": "Enter the Cloudware domain name"
@@ -42,7 +42,7 @@
   "variables": {
     "adminUsername": "alces",
     "adminPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/0R5EvmSrySy2I+8Cx6eOX7cVuYFXx5D0O1x0+OmAZ0Qaj9d7E0Nj4ZcWxdCT03uFl1Ka4tInDlQmMyy0V1/AftpHxBEnB17Pk/lJnDW1YstmAqD0GlFa1CrxUdtHd+jB3LJmdoHsV6fRGpMOgFd+u/4Wces7KAqYFmL5uPG1UTCMgokQ2qboQgEVspXotMvni1iil3kEjyH/eW64Laxmn2Vxls9feZ1o95mPQhJPJcN7MMo1h+jkxyat3bawtpqyV7fXYU0+BO2JHpu/VIEDHtxhlk7RhI0U06XbJu6ZCCUrEX8idIhw4hueQpKwVYplTXssa9JqNlcjouqLj5kd cloudware@alces-software.com",
-    "priInterfaceName": "[concat(parameters('cloudwareDomain'), parameters('vmName'), 'pri')]",
+    "priInterfaceName": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), 'pri')]",
     "azureConfig": {
       "imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/alcesflight/providers/Microsoft.Compute/images/alces-flight-compute-1.0.0-beta')]"
     }
@@ -52,7 +52,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
@@ -77,18 +77,18 @@
     "name": "[variables('priInterfaceName')]",
     "apiVersion": "2017-03-01",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_machine_name": "[parameters('vmName')]"
     },
     "location": "[resourceGroup().location]",
     "properties": {
       "ipConfigurations": [{
-        "name": "[concat(parameters('cloudwareDomain'), parameters('vmName'), '-pri')]",
+        "name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
         "properties": {
           "privateIPAllocationMethod": "Static",
           "privateIPAddress": "[parameters('priSubnetIp')]",
           "subnet": {
-            "id": "[resourceId(parameters('cloudwareDomain'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
+            "id": "[resourceId(parameters('cloudwareDomainGroup'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
           }
         }
       }],
@@ -105,7 +105,7 @@
     "name": "[parameters('vmName')]",
     "apiVersion": "2016-04-30-preview",
     "tags": {
-      "cloudware_domain": "[parameters('cloudwareDomain')]",
+      "cloudware_domain": "[parameters('cloudwareDomainGroup')]",
       "cloudware_id": "[parameters('cloudwareId')]",
       "cloudware_machine_name": "[parameters('vmName')]",
       "cloudware_machine_role": "slave",

--- a/providers/azure/templates/machine-slave.json
+++ b/providers/azure/templates/machine-slave.json
@@ -38,7 +38,7 @@
         "description": "Choose the VM flavour"
       }
     },
-    "priSubnetIp": {
+    "priIp": {
       "type": "string",
       "metadata": {
         "description": "Enter the desired pri subnet IP address"
@@ -92,7 +92,7 @@
         "name": "[concat(parameters('cloudwareDomainGroup'), parameters('vmName'), '-pri')]",
         "properties": {
           "privateIPAllocationMethod": "Static",
-          "privateIPAddress": "[parameters('priSubnetIp')]",
+          "privateIPAddress": "[parameters('priIp')]",
           "subnet": {
             "id": "[resourceId(parameters('cloudwareDomainGroup'), 'Microsoft.Network/virtualNetworks/subnets', 'network', 'pri')]"
           }
@@ -118,7 +118,7 @@
       "cloudware_machine_type": "[parameters('vmType')]",
       "cloudware_machine_flavour": "[parameters('vmFlavour')]",
       "cloudware_resource_type": "machine",
-      "cloudware_pri_ip": "[parameters('priSubnetIp')]"
+      "cloudware_pri_ip": "[parameters('priIp')]"
     },
     "location": "[resourceGroup().location]",
     "properties": {

--- a/providers/azure/templates/machine-slave.json
+++ b/providers/azure/templates/machine-slave.json
@@ -5,6 +5,12 @@
     "cloudwareDomainGroup": {
       "type": "string",
       "metadata": {
+        "description": "Enter the Cloudware domain resource group name"
+      }
+    },
+    "cloudwareDomain": {
+      "type": "string",
+      "metadata": {
         "description": "Enter the Cloudware domain name"
       }
     },


### PR DESCRIPTION
Based on #104 

Fixed a few bugs where the template/ model classes assumed that machines had public `ip` addresses. This isn't the case for `compute` nodes and thus was causing a couple of errors.