### PR TITLE
Additional CloudInit Improvements

### DIFF
--- a/providers/aws/templates/machine-compute.yml
+++ b/providers/aws/templates/machine-compute.yml
@@ -170,3 +170,25 @@ Resources:
         -
           Key: 'cloudware_pri_subnet_ip'
           Value: !Ref priIp
+      UserData:
+        Fn::Base64:
+          Fn::Join:
+            - ''
+            - - "#cloud-config\n"
+              - Fn::Join:
+                - ''
+                - - "hostname: "
+                  - Ref: vmName
+                  - "\n"
+              - Fn::Join:
+                - ''
+                - - "fqdn: "
+                  - Ref: vmName
+                  - '.'
+                  - Fn::Join:
+                    - "."
+                    - Fn::Split:
+                      - "-"
+                      - Ref: cloudwareDomain
+                  - "\n"
+              - "\n"

--- a/providers/aws/templates/machine-gateway.yml
+++ b/providers/aws/templates/machine-gateway.yml
@@ -153,6 +153,19 @@ Resources:
         -
           Key: 'cloudware_pri_subnet_ip'
           Value: 10.78.100.10
+      UserData:
+        Fn::Base64:
+          Fn::Join:
+            - ''
+            - - "#cloud-config\n"
+              - "hostname: gateway\n"
+              - "fqdn: gateway."
+              - Fn::Join:
+                - "."
+                - Fn::Split:
+                  - "-"
+                  - Ref: cloudwareDomain
+              - "\n"
 
   publicIp:
     Type: AWS::EC2::EIP

--- a/providers/aws/templates/machine-gateway.yml
+++ b/providers/aws/templates/machine-gateway.yml
@@ -166,6 +166,9 @@ Resources:
                   - "-"
                   - Ref: cloudwareDomain
               - "\n"
+              - "runcmd:\n"
+              - "- [ sh, -c, 'curl https://raw.githubusercontent.com/alces-software/cloudware/develop/support/flightconnector/domain0-gateway.sh | /bin/bash' ]"
+
 
   publicIp:
     Type: AWS::EC2::EIP

--- a/providers/aws/templates/machine-login.yml
+++ b/providers/aws/templates/machine-login.yml
@@ -160,6 +160,19 @@ Resources:
         -
           Key: 'cloudware_pri_subnet_ip'
           Value: !Join ['', ['10.100.', !Ref clusterIndex, '.10']]
+      UserData:
+        Fn::Base64:
+          Fn::Join:
+            - ''
+            - - "#cloud-config\n"
+              - "hostname: login\n"
+              - "fqdn: login."
+              - Fn::Join:
+                - "."
+                - Fn::Split:
+                  - "-"
+                  - Ref: cloudwareDomain
+              - "\n"
 
   publicIp:
     Type: AWS::EC2::EIP

--- a/support/build/centos7.tdl
+++ b/support/build/centos7.tdl
@@ -8,7 +8,7 @@
     <version>0</version>
     <arch>x86_64</arch>
     <install type='iso'>
-      <iso>http://mirror.ox.ac.uk/sites/mirror.centos.org/7/isos/x86_64/CentOS-7-x86_64-DVD-1708.iso</iso>
+      <iso>http://mirror.ox.ac.uk/sites/mirror.centos.org/7/isos/x86_64/CentOS-7-x86_64-DVD-1804.iso</iso>
     </install>
   </os>
   <description>CentOS 7 Base Install</description>


### PR DESCRIPTION
This PR will address the configuration of the AMIs, namely adding the following functionality:

- Set Hostname & FQDN for:

  - Gateway
  - Login
  - Nodes

- Run dom0 configuration script on startup

## Caveats

While this PR does allow for the FQDN to be set it requires that the cloudware domain name reflect the desired FQDN. For example, if you want the gateway FQDN to be `gateway.dom0.mynetwork.alces.network` then the cloudware domain name will need to be `dom0-mynetwork-alces-network`.