### PR TITLE
Fix bug where Whirly doesn't always run

### DIFF
--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -53,13 +53,15 @@ module Cloudware
 
     def run_whirly(status)
       update_status = proc { |s| Whirly.status = s.bold }
+      been_ran = false
       result = nil
       Whirly.start do
+        been_ran = true
         update_status.call(status)
         Whirly.stop if options.debug
         result = yield update_status if block_given?
       end
-      result
+      been_ran ? result : (yield update_status if block_given?)
     end
   end
 end


### PR DESCRIPTION
If `Whirly` is used in a non-interactive mode, it doesn't run the block.
This means the commands can't be used in pipes.

The fix is to flag if the code block hasn't been ran and then run it

Fixes #120 