### PR TITLE
Rebuild `cloudware` config and invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ tmp/
 var/
 log/
 etc/config.*
-!etc/config.yml.example
+!etc/config.yaml.example
 vendor/
 .bundle/

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ var/
 log/
 etc/config.*
 !etc/config.yaml.example
+!etc/config.yaml.travis
 vendor/
 .bundle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
  - 2.4.1
 sudo: required
 install:
-  - cp ./etc/config.yml.example ./etc/config.yml
+  - cp ./etc/config.yaml.example ./etc/config.yaml
   - sed -i 's#/var/log#/tmp#g' ./etc/config.yml
   - touch /tmp/flightconnector.log
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ rvm:
  - 2.4.1
 sudo: required
 install:
-  - cp ./etc/config.yaml.example ./etc/config.yaml
-  - sed -i 's#/var/log#/tmp#g' ./etc/config.yml
-  - touch /tmp/flightconnector.log
+  - cp ./etc/config.yaml.travis ./etc/config.yaml
+  - touch /tmp/travis.log
   - bundle install
 script:
   - export CLOUDWARE_PROVIDER=aws

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'tty-table'
 
 group :config do
   gem 'activesupport'
-  gem 'tty-config'
+  gem 'flight_config', git: 'https://github.com/alces-software/flight_config'
 end
 
 group :aws do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     jmespath (1.3.1)
     kramdown (1.16.2)
     memoist (0.16.0)
-    method_source (0.9.0)
+    method_source (0.9.2)
     minitest (5.11.3)
     ms_rest (0.7.2)
       concurrent-ruby (~> 1.0)
@@ -84,7 +84,8 @@ GEM
       equatable (~> 0.5.0)
       tty-color (~> 0.4.0)
     powerpack (0.1.1)
-    pry (0.11.3)
+    pp (0.1.1)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-byebug (3.6.0)
@@ -168,6 +169,7 @@ DEPENDENCIES
   ipaddr
   memoist
   parallel
+  pp
   pry
   pry-byebug
   require_all

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,13 @@ GIT
     commander (4.4.4.pre.alces2)
       highline (~> 1.7.2)
 
+GIT
+  remote: https://github.com/alces-software/flight_config
+  revision: e3135c14acb6599f4bc3d13ffea955a943d40e31
+  specs:
+    flight_config (0.1.0)
+      tty-config
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -117,7 +124,7 @@ GEM
     thread_safe (0.3.6)
     timeliness (0.3.8)
     tty-color (0.4.3)
-    tty-config (0.3.0)
+    tty-config (0.3.1)
     tty-cursor (0.6.0)
     tty-markdown (0.4.0)
       kramdown (~> 1.16.2)
@@ -157,6 +164,7 @@ DEPENDENCIES
   commander!
   factory_bot
   fakefs
+  flight_config!
   ipaddr
   memoist
   parallel
@@ -167,7 +175,6 @@ DEPENDENCIES
   rspec-wait
   rubocop (~> 0.52.1)
   rubocop-rspec
-  tty-config
   tty-markdown
   tty-spinner
   tty-table

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: e3135c14acb6599f4bc3d13ffea955a943d40e31
+  revision: de4d05a03aa3aec791cc1429da346cda84b38527
   specs:
     flight_config (0.1.0)
       tty-config
@@ -84,7 +84,6 @@ GEM
       equatable (~> 0.5.0)
       tty-color (~> 0.4.0)
     powerpack (0.1.1)
-    pp (0.1.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -169,7 +168,6 @@ DEPENDENCIES
   ipaddr
   memoist
   parallel
-  pp
   pry
   pry-byebug
   require_all

--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,25 @@
 # frozen_string_literal: true
 
 ENV['CLOUDWARE_DEBUG'] = 'true'
-require_relative 'lib/cloudware.rb'
 
-task :console do
+task :setup do
+  ENV['BUNDLE_GEMFILE'] = File.join(__dir__, 'Gemfile')
+
+  require 'rubygems'
+  require 'bundler'
+
+  Bundler.setup(:development)
+  require 'pp'
+  require 'pry'
+  require 'pry-byebug'
+
+  Bundler.setup(:default, :config, :aws, :azure)
+
+  $LOAD_PATH.unshift(File.join(__dir__, 'lib'))
+  require 'cloudware'
+end
+
+task console: :setup do
   Pry::REPL.start({})
 end
 

--- a/bin/cloud
+++ b/bin/cloud
@@ -34,15 +34,22 @@ Thread.report_on_exception = false
 require 'rubygems'
 require 'bundler'
 
-# Require the config and associated gems
-Bundler.require(:config)
-require 'cloudware/config'
+# Catch any config errors during the require/setup
+begin
+  # Require the config and associated gems
+  Bundler.require(:config)
+  require 'cloudware/config'
 
-# Require the development gems
-Bundler.require(:development) if Cloudware::Config.debug
+  # Require the development gems
+  Bundler.require(:development) if Cloudware::Config.debug
 
-# Setup the load path for remaining gems
-Bundler.setup(:default, Cloudware::Config.provider)
+  # Setup the load path for remaining gems
+  Bundler.setup(:default, Cloudware::Config.provider)
 
-require 'cloudware'
+  require 'cloudware'
+rescue Cloudware::ConfigError => e
+  $stderr.puts e.message
+  exit 1
+end
+
 Cloudware::CLI.run! if $PROGRAM_NAME == __FILE__

--- a/bin/cloud
+++ b/bin/cloud
@@ -41,7 +41,13 @@ begin
   require 'cloudware/config'
 
   # Require the development gems
-  Bundler.require(:development) if Cloudware::Config.debug
+  if Cloudware::Config.debug
+    # `pry` needs to be required in a specific order so it doesn't clash with `pp`
+    Bundler.setup(:development)
+    require 'pp'
+    require 'pry'
+    require 'pry-byebug'
+  end
 
   # Setup the load path for remaining gems
   Bundler.setup(:default, Cloudware::Config.provider)

--- a/etc/config.yaml.example
+++ b/etc/config.yaml.example
@@ -1,5 +1,5 @@
 # Please fill this file out with your aws and azure keys
-# and renamed: "etc/config.yml"
+# and renamed: "etc/config.yaml"
 
 # Provider credentials
 azure:

--- a/etc/config.yaml.example
+++ b/etc/config.yaml.example
@@ -1,22 +1,29 @@
-# Please fill this file out with your aws and azure keys
-# and renamed: "etc/config.yaml"
+# =============================================================================
+# GETTING STARTED
+# Please COPY this file into place, please leave this example as a reference.
+#
+# cp etc/config.yaml.example etc/config.yaml
+#
+# Only the credentials for the installed providers are required. See comments
+# for details.
+# =============================================================================
 
 # Provider credentials
-azure:
-  default_region:
-  tenant_id:
-  subscription_id:
-  client_secret:
-  client_id:
+azure:                        # Requirement for cloud-azure
+  default_region:   # [VALUE] : Requirement for cloud-azure
+  tenant_id:        # [VALUE] : Requirement for cloud-azure
+  subscription_id:  # [VALUE] : Requirement for cloud-azure
+  client_secret:    # [VALUE] : Requirement for cloud-azure
+  client_id:        # [VALUE] : Requirement for cloud-azure
 
-aws:
-  default_region:
-  access_key_id:
-  secret_access_key:
+aws:                            # Requirement for cloud-aws
+  default_region:     # [VALUE] : Requirement for cloud-aws
+  access_key_id:      # [VALUE] : Requirement for cloud-aws
+  secret_access_key:  # [VALUE] : Requirement for cloud-aws
 
 # ADVANCED CONFIGURATION (Optional)
-
-# ============================================================================
+# =============================================================================
+# and renamed: "etc/config.yaml"
 # Content Directory
 # By default cloudware stores its content within the <install-dir>/var
 # directory. This can be optionally changed to a different location

--- a/etc/config.yaml.travis
+++ b/etc/config.yaml.travis
@@ -1,0 +1,13 @@
+azure:                        # Requirement for cloud-azure
+  default_region:   # [VALUE] : Requirement for cloud-azure
+  tenant_id:        # [VALUE] : Requirement for cloud-azure
+  subscription_id:  # [VALUE] : Requirement for cloud-azure
+  client_secret:    # [VALUE] : Requirement for cloud-azure
+  client_id:        # [VALUE] : Requirement for cloud-azure
+
+aws:                            # Requirement for cloud-aws
+  default_region:     # [VALUE] : Requirement for cloud-aws
+  access_key_id:      # [VALUE] : Requirement for cloud-aws
+  secret_access_key:  # [VALUE] : Requirement for cloud-aws
+
+log_file: /tmp/travis.log

--- a/lib/cloudware.rb
+++ b/lib/cloudware.rb
@@ -26,12 +26,6 @@
 
 # ActiveSupport modules
 require 'active_support/core_ext/string'
-require 'active_support/core_ext/array'
-require 'active_model'
-require 'active_model/errors'
-
-require 'colorize'
-require 'memoist'
 
 require 'cloudware/config'
 require 'cloudware/cli'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -62,7 +62,12 @@ module Cloudware
 
     def self.action(command, klass, method: :run!)
       command.action do |args, options|
-        klass.new(args, options).public_send(method)
+        begin
+          klass.new.public_send(method, *args, **options.__hash__)
+        rescue Exception => e
+          Log.fatal(e.message)
+          raise e
+        end
       end
     end
 

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -60,9 +60,9 @@ module Cloudware
     # Display the help if there is no input arguments
     ARGV.push '--help' if ARGV.empty?
 
-    def self.action(command, klass)
+    def self.action(command, klass, method: :run!)
       command.action do |args, options|
-        klass.new(args, options).run!
+        klass.new(args, options).public_send(method)
       end
     end
 

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -80,6 +80,8 @@ module Cloudware
     end
 
     def self.cli_syntax(command, args_str = '')
+      command.hidden = true if command.name.split.length > 1
+      command.sub_command_group = true
       command.syntax = <<~SYNTAX.squish
         #{program(:name)} #{command.name} #{args_str} [options]
       SYNTAX
@@ -88,13 +90,11 @@ module Cloudware
     command 'cluster' do |c|
       cli_syntax(c)
       c.summary = 'Manage the current cluster selection'
-      c.sub_command_group = true
     end
 
     command 'cluster switch' do |c|
       cli_syntax(c, 'CLUSTER')
       c.summary = 'Change the current cluster to CLUSTER'
-      c.hidden = true
       action(c, Commands::Cluster, method: :switch)
     end
 
@@ -131,7 +131,6 @@ module Cloudware
     command 'list' do |c|
       cli_syntax(c)
       c.summary = 'List the deployed cloud resources'
-      c.sub_command_group = true
     end
 
     list_clusters_proc = proc do |c|
@@ -140,7 +139,6 @@ module Cloudware
       c.description = <<~DESC
         Shows a list of clusters that have been previously deployed to
       DESC
-      c.hidden = true
       action(c, Commands::Cluster, method: :list)
     end
 
@@ -150,7 +148,6 @@ module Cloudware
     command 'list deployments' do |c|
       cli_syntax(c)
       c.description = 'List all the previous deployed templates'
-      c.hidden = true
       c.option '-v', '--verbose', 'Show full error messages'
       action(c, Commands::Lists::Deployment)
     end
@@ -165,14 +162,12 @@ module Cloudware
         Instead it list the deployment outputs which follow the machine tag
         format: `<machine-name>TAG<key>`
       DESC
-      c.hidden = true
       action(c, Commands::Lists::Machine)
     end
 
     command 'power' do |c|
       cli_syntax(c)
       c.description = 'Start or stop machine and check their power status'
-      c.sub_command_group = true
     end
 
     def self.shared_power_attr(c)
@@ -182,7 +177,6 @@ module Cloudware
       c.option '-g', '--group', <<~DESC
         Preform the '#{action}' action on machine in group '#{cli_attr}'
       DESC
-      c.hidden = true
     end
 
     command 'power status' do |c|

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -25,19 +25,14 @@
 #
 
 require 'commander'
-require 'cloudware/exceptions'
 
-require 'cloudware/config'
 require 'cloudware/command'
 require 'cloudware/version'
-require 'cloudware/config'
 
 require 'require_all'
 
 # Require all the following paths
 [
-  'lib/cloudware/models/concerns/**/*.rb',
-  'lib/cloudware/models/**/*.rb',
   'lib/cloudware/commands/concerns/**/*.rb',
   'lib/cloudware/commands/**/*.rb',
 ].each { |path| require_all File.join(Cloudware::Config.root_dir, path) }
@@ -62,6 +57,7 @@ module Cloudware
 
     def self.action(command, klass, method: :run!)
       command.action do |args, options|
+        delayed_require
         hash = options.__hash__
         hash.delete(:trace)
         begin
@@ -85,6 +81,13 @@ module Cloudware
       command.syntax = <<~SYNTAX.squish
         #{program(:name)} #{command.name} #{args_str} [options]
       SYNTAX
+    end
+
+    def self.delayed_require
+      [
+        'lib/cloudware/models/concerns/**/*.rb',
+        'lib/cloudware/models/**/*.rb',
+      ].each { |path| require_all File.join(Cloudware::Config.root_dir, path) }
     end
 
     command 'cluster' do |c|

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -62,8 +62,11 @@ module Cloudware
 
     def self.action(command, klass, method: :run!)
       command.action do |args, options|
+        hash = options.__hash__
         begin
-          klass.new.public_send(method, *args, **options.__hash__)
+          cmd = klass.new
+          cmd.__config__.region = hash.delete(:region)
+          cmd.public_send(method, *args, **hash)
         rescue Exception => e
           Log.fatal(e.message)
           raise e

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -134,6 +134,19 @@ module Cloudware
       c.sub_command_group = true
     end
 
+    list_clusters_proc = proc do |c|
+      cli_syntax(c)
+      c.summary = 'Show the current and available clusters'
+      c.description = <<~DESC
+        Shows a list of clusters that have been previously deployed to
+      DESC
+      c.hidden = true
+      action(c, Commands::Cluster, method: :list)
+    end
+
+    command('list clusters', &list_clusters_proc)
+    command('cluster list', &list_clusters_proc)
+
     command 'list deployments' do |c|
       cli_syntax(c)
       c.description = 'List all the previous deployed templates'

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -27,6 +27,7 @@
 require 'cloudware/spinner'
 require 'cloudware/log'
 require 'cloudware/command_config'
+require 'memoist'
 
 module Cloudware
   class Command

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -58,7 +58,7 @@ module Cloudware
     memoize :context
 
     def region
-      __config.__.region
+      __config__.region
     end
   end
 end

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -26,23 +26,24 @@
 
 require 'cloudware/spinner'
 require 'cloudware/log'
+require 'cloudware/command_config'
 
 module Cloudware
   class Command
     extend Memoist
     include WithSpinner
 
-    def initialize(argv, options)
-      @__config__ = CommandConfig.load
-      @argv = argv.freeze
-      @options = OpenStruct.new(options.__hash__)
+    def initialize(__config__ = nil)
+      @__config__ = __config__ || CommandConfig.load
     end
 
-    def run!
+    def run!(*argv, **options)
+      class << self
+        attr_reader :argv, :options
+      end
+      @argv = argv.freeze
+      @options = OpenStruct.new(options)
       run
-    rescue Exception => e
-      Log.fatal(e.message)
-      raise e
     end
 
     def run
@@ -60,6 +61,6 @@ module Cloudware
 
     private
 
-    attr_reader :argv, :options, :__config__
+    attr_reader :__config__
   end
 end

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -33,6 +33,8 @@ module Cloudware
     extend Memoist
     include WithSpinner
 
+    attr_reader :__config__
+
     def initialize(__config__ = nil)
       @__config__ = __config__ || CommandConfig.load
     end
@@ -51,16 +53,12 @@ module Cloudware
     end
 
     def context
-      Context.new(region: options.region)
+      Context.new(region: __config__.region)
     end
     memoize :context
 
     def region
-      options.region || Config.default_region
+      __config.__.region
     end
-
-    private
-
-    attr_reader :__config__
   end
 end

--- a/lib/cloudware/command_config.rb
+++ b/lib/cloudware/command_config.rb
@@ -25,7 +25,6 @@
 #
 
 require 'cloudware/config'
-require 'flight_config/updater'
 require 'active_support/core_ext/module/delegation'
 
 module Cloudware

--- a/lib/cloudware/command_config.rb
+++ b/lib/cloudware/command_config.rb
@@ -34,6 +34,17 @@ module Cloudware
 
     delegate_missing_to Config
 
+    def path
+      File.join(content_path, 'etc/config.yaml')
+    end
+
+    def current_cluster
+      __data__.fetch(:current_cluster) { 'default' }
+    end
+
+    def current_cluster=(cluster)
+      __data__.set(:current_cluster, value: cluster)
+    end
   end
 end
 

--- a/lib/cloudware/command_config.rb
+++ b/lib/cloudware/command_config.rb
@@ -24,42 +24,16 @@
 # ==============================================================================
 #
 
-require 'cloudware/spinner'
-require 'cloudware/log'
+require 'cloudware/config'
+require 'flight_config/updater'
+require 'active_support/core_ext/module/delegation'
 
 module Cloudware
-  class Command
-    extend Memoist
-    include WithSpinner
+  class CommandConfig
+    include FlightConfig::Updater
 
-    def initialize(argv, options)
-      @__config__ = CommandConfig.load
-      @argv = argv.freeze
-      @options = OpenStruct.new(options.__hash__)
-    end
+    delegate_missing_to Config
 
-    def run!
-      run
-    rescue Exception => e
-      Log.fatal(e.message)
-      raise e
-    end
-
-    def run
-      raise NotImplementedError
-    end
-
-    def context
-      Context.new(region: options.region)
-    end
-    memoize :context
-
-    def region
-      options.region || Config.default_region
-    end
-
-    private
-
-    attr_reader :argv, :options, :__config__
   end
 end
+

--- a/lib/cloudware/command_config.rb
+++ b/lib/cloudware/command_config.rb
@@ -44,6 +44,14 @@ module Cloudware
     def current_cluster=(cluster)
       __data__.set(:current_cluster, value: cluster)
     end
+
+    def region
+      @region ||= Config.default_region
+    end
+
+    def region=(region)
+      @region = region
+    end
   end
 end
 

--- a/lib/cloudware/commands/cluster.rb
+++ b/lib/cloudware/commands/cluster.rb
@@ -27,10 +27,27 @@
 module Cloudware
   module Commands
     class Cluster < Command
+      LIST_TEMPLATE = <<~ERB
+        <% clusters.each do |cluster| -%>
+        <%   current = __config__.current_cluster == cluster -%>
+        <%=  current ? '*' : ' ' %> <%= cluster %>
+        <% end -%>
+      ERB
+
       def switch(cluster)
         @__config__ = CommandConfig.update do |conf|
           conf.current_cluster = cluster
         end
+      end
+
+      def list
+        puts ERB.new(LIST_TEMPLATE, nil, '-').result(binding)
+      end
+
+      private
+
+      def clusters
+        []
       end
     end
   end

--- a/lib/cloudware/commands/cluster.rb
+++ b/lib/cloudware/commands/cluster.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#
+# =============================================================================
+# Copyright (C) 2019 Stephen F. Norledge and Alces Flight Ltd
+#
+# This file is part of Alces Cloudware.
+#
+# Alces Cloudware is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Alces Cloudware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Alces Cloudware.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Cloudware, please visit:
+# https://github.com/alces-software/cloudware
+# ==============================================================================
+#
+
+module Cloudware
+  module Commands
+    class Cluster < Command
+      def switch(cluster)
+        @__config__ = CommandConfig.update do |conf|
+          conf.current_cluster = cluster
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -24,13 +24,16 @@
 # ==============================================================================
 #
 
-require 'cloudware/models/deployment'
-require 'cloudware/replacement_factory'
-
 module Cloudware
   module Commands
     class Deploy < Command
       attr_reader :name, :template_path
+
+      def initialize(*a, **h)
+        require 'cloudware/models/deployment'
+        require 'cloudware/replacement_factory'
+        super
+      end
 
       def run
         @name = argv[0]

--- a/lib/cloudware/commands/destroy.rb
+++ b/lib/cloudware/commands/destroy.rb
@@ -24,12 +24,15 @@
 # ==============================================================================
 #
 
-require 'cloudware/models/deployment'
-
 module Cloudware
   module Commands
     class Destroy < Command
       attr_reader :name
+
+      def initialize(*a, **h)
+        require 'cloudware/models/deployment'
+        super
+      end
 
       def run
         @name = argv[0]

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -45,9 +45,6 @@ module Cloudware
     def initialize
       __data__.env_prefix = 'cloudware'
       ['provider', 'debug', 'app_name'].each { |x| __data__.set_from_env(x) }
-
-      # Ensures the providers credentials have been loaded
-      public_send(provider)
     end
 
     def path

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -44,15 +44,15 @@ module Cloudware
     end
 
     def initialize
-      @config = TTY::Config.new
-      config.prepend_path(File.join(self.class.root_dir, 'etc'))
-      config.env_prefix = 'cloudware'
-      ['provider', 'debug', 'app_name'].each { |x| config.set_from_env(x) }
+      @__data__ = TTY::Config.new
+      __data__.prepend_path(File.join(self.class.root_dir, 'etc'))
+      __data__.env_prefix = 'cloudware'
+      ['provider', 'debug', 'app_name'].each { |x| __data__.set_from_env(x) }
       load_config
     end
 
     def log_file
-      config.fetch(:log_file) do
+      __data__.fetch(:log_file) do
         File.join(self.class.root_dir, 'log', 'cloudware.log').tap do |path|
           FileUtils.mkdir_p(File.dirname(path))
         end
@@ -60,7 +60,7 @@ module Cloudware
     end
 
     def provider
-      config.fetch(:provider) do
+      __data__.fetch(:provider) do
         warn 'No provider specified'
         exit 1
       end
@@ -68,34 +68,34 @@ module Cloudware
 
     [:azure, :aws].each do |init_provider|
       define_method(init_provider) do
-        OpenStruct.new(config.fetch(init_provider))
+        OpenStruct.new(__data__.fetch(init_provider))
       end
     end
 
     def default_region
-      config.fetch(provider, :default_region)
+      __data__.fetch(provider, :default_region)
     end
 
     def content_path
-      config.fetch(:content_directory) do
+      __data__.fetch(:content_directory) do
         File.join(self.class.root_dir, 'var')
       end
     end
 
     def debug
-      !!config.fetch(:debug)
+      !!__data__.fetch(:debug)
     end
 
     def app_name
-      config.fetch(:app_name) { File.basename($PROGRAM_NAME) }
+      __data__.fetch(:app_name) { File.basename($PROGRAM_NAME) }
     end
 
     private
 
-    attr_reader :config
+    attr_reader :__data__
 
     def load_config
-      config.read
+      __data__.read
     rescue TTY::Config::ReadError
       missing_config_error
     rescue
@@ -113,7 +113,7 @@ module Cloudware
     def invalid_config_error
       warn <<~ERROR.chomp
         An error occurred when loading the config file:
-        #{config.source_file}
+        #{__data__.source_file}
       ERROR
       exit 1
     end

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -25,7 +25,7 @@
 #
 
 require 'ostruct'
-require 'tty-config'
+require 'flight_config/loader'
 
 require 'active_support/core_ext/module/delegation'
 

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -25,7 +25,7 @@
 #
 
 require 'ostruct'
-require 'flight_config/loader'
+require 'flight_config'
 require 'active_support/core_ext/module/delegation'
 
 require 'cloudware/exceptions'

--- a/lib/cloudware/context.rb
+++ b/lib/cloudware/context.rb
@@ -29,8 +29,8 @@ module Cloudware
     attr_reader :region, :deployments
     delegate :provider, to: Config
 
-    def initialize(region: nil)
-      @region = region || Config.default_region
+    def initialize(region:)
+      @region = region
       update_deployments
     end
 

--- a/lib/cloudware/models/application.rb
+++ b/lib/cloudware/models/application.rb
@@ -24,6 +24,9 @@
 # ==============================================================================
 #
 
+require 'active_model'
+require 'active_model/errors'
+
 module Cloudware
   module Models
     class Application


### PR DESCRIPTION
Cloudware now uses `FlightConfig` to manage its internal configs. It uses the same double `Config` pattern as `underware`. There is a core static `Config` class that should only be edited at install time.

Then there is a second `CommandConfig` that stores the dynamic configuration. In the case of `cloudware`, it comes with the `cluster` attribute so it can support multiple clusters in the future. It also has the `region` attribute, as this is a global option and and comprises the "state" of cloudware.

The invocation of cloudware has also been updated to decouple the `Commands` from `Commander`. Each command is created with an instance of `CommanderConfig` which hides the global options. Also the commands are executed using regular hashes, removing `Commander::Command::Option`.