### PR TITLE
Update the file paths when importing templates

### DIFF
--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -107,7 +107,7 @@ module Cloudware
         verbose option to see the full template paths
       DESC
       c.option '--verbose', 'Show the shorthand mappigns'
-      action(c, Commands::ClusterCmd, method: :list_templates)
+      action(c, Commands::Deploy, method: :list_templates)
     end
 
     command 'cluster templates', &cluster_templates

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -113,8 +113,7 @@ module Cloudware
       c.summary = 'Deploy new resource(s) define by a template'
       c.description = <<-DESC.strip_heredoc
         Deploy new resource(s) from the specified TEMPLATE. The TEMPLATE can
-        either be a cluster template (see #{Config.app_name} cluster templates).
-        Alternatively, an absolute path (including extension) can be used.
+        either be a cluster template or an absolute path.
 
         The deployment will be given the NAME label and logged locally. The name
         used by the provider will be based off this with minor variations.

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -92,7 +92,7 @@ module Cloudware
     command 'cluster switch' do |c|
       cli_syntax(c, 'CLUSTER')
       c.summary = 'Change the current cluster to CLUSTER'
-      action(c, Commands::ClusterCmd, method: :switch)
+      action(c, Commands::ClusterCommand, method: :switch)
     end
 
     cluster_templates = proc do |c|
@@ -168,7 +168,7 @@ module Cloudware
       c.description = <<~DESC
         Shows a list of clusters that have been previously deployed to
       DESC
-      action(c, Commands::ClusterCmd, method: :list)
+      action(c, Commands::ClusterCommand, method: :list)
     end
 
     command('list clusters', &list_clusters_proc)

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -101,6 +101,10 @@ module Cloudware
       c.description = <<~DESC
         Lists the templates for a particular cluster. These templates
         can be used directly with the `deploy` command.
+
+        A shorthand is available when the template name matches its
+        directory. If the tempate path is unambiguous, then the
+        directory name maybe used with the deploy command.
       DESC
       action(c, Commands::ClusterCmd, method: :list_templates)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -84,9 +84,21 @@ module Cloudware
       require 'cloudware/models'
     end
 
+    def self.add_command(name, *args)
+      command name do |c|
+        cli_syntax(c, *args)
+        yield c
+      end
+    end
+
     command 'cluster' do |c|
       cli_syntax(c)
       c.summary = 'Manage the current cluster selection'
+    end
+
+    add_command 'cluster init', 'CLUSTER' do |c|
+      c.summary = 'Create a new cluster'
+      action(c, Commands::ClusterCommand, method: :init)
     end
 
     command 'cluster switch' do |c|

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -102,10 +102,11 @@ module Cloudware
         Lists the templates for a particular cluster. These templates
         can be used directly with the `deploy` command.
 
-        A shorthand is available when the template name matches its
-        directory. If the tempate path is unambiguous, then the
-        directory name maybe used with the deploy command.
+        By default the template name is not required if it can be
+        unambiguously determined from the directory name. Use the
+        verbose option to see the full template paths
       DESC
+      c.option '--verbose', 'Show the shorthand mappigns'
       action(c, Commands::ClusterCmd, method: :list_templates)
     end
 

--- a/lib/cloudware/cluster.rb
+++ b/lib/cloudware/cluster.rb
@@ -35,7 +35,7 @@ module Cloudware
     end
 
     def join(*paths)
-      Config.content('clusters', identifier, *paths)
+      Pathname.new(Config.content('clusters', identifier, *paths))
     end
 
     # Deprecated! Use `join` instead
@@ -49,7 +49,7 @@ module Cloudware
 
     def template(*parts, ext: true)
       path = join('lib', 'templates', *parts)
-      ext ? "#{path}#{Config.template_ext}" : path
+      ext ? path.sub_ext(Config.template_ext) : path
     end
 
     def region

--- a/lib/cloudware/commands/cluster.rb
+++ b/lib/cloudware/commands/cluster.rb
@@ -59,7 +59,9 @@ module Cloudware
         if list.templates.empty?
           $stderr.puts 'No templates found'
         else
-          puts list.human_paths
+          list.human_paths.each do |path, shorthand|
+            puts shorthand || path
+          end
         end
       end
 
@@ -89,12 +91,10 @@ module Cloudware
             relative_base = template.dirname.relative_path_from(base)
 
             # Detect shorthand enabled templates
-            if name == dir_name && !alternate.file?
-              "#{relative_base} => #{relative_base}/#{name}"
-            else
-              "#{relative_base}/#{name}"
-            end
-          end
+            shorthand = (name == dir_name && !alternate.file?)
+
+            [File.join(relative_base, name), shorthand ? relative_base : nil]
+          end.to_h
         end
 
         def templates

--- a/lib/cloudware/commands/cluster.rb
+++ b/lib/cloudware/commands/cluster.rb
@@ -55,6 +55,7 @@ module Cloudware
       end
 
       def list_templates
+        list = ListTemplates.build(__config__.current_cluster)
         cluster = Cluster.load(__config__.current_cluster)
         templates = Dir.glob(cluster.template('**/*')).sort
         if templates.empty?
@@ -69,6 +70,12 @@ module Cloudware
       end
 
       private
+
+      ListTemplates = Struct.new(:cluster) do
+        def self.build(cluster_name)
+          new(Cluster.load(cluster_name))
+        end
+      end
 
       def clusters
         Dir.glob(Cluster.new('*').directory)

--- a/lib/cloudware/commands/cluster.rb
+++ b/lib/cloudware/commands/cluster.rb
@@ -82,8 +82,18 @@ module Cloudware
         # These represent the valid template CLI inputs
         #
         def human_paths
-          templates.map do |path|
-            path.relative_path_from(base).sub_ext('')
+          templates.map do |template|
+            name = template.basename.sub_ext('')
+            dir_name = template.dirname.basename
+            alternate = template.dirname.dirname.join(template.basename)
+            relative_base = template.dirname.relative_path_from(base)
+
+            # Detect shorthand enabled templates
+            if name == dir_name && !alternate.file?
+              "#{relative_base} => #{relative_base}/#{name}"
+            else
+              "#{relative_base}/#{name}"
+            end
           end
         end
 

--- a/lib/cloudware/commands/cluster.rb
+++ b/lib/cloudware/commands/cluster.rb
@@ -56,15 +56,10 @@ module Cloudware
 
       def list_templates
         list = ListTemplates.build(__config__.current_cluster)
-        cluster = Cluster.load(__config__.current_cluster)
         if list.templates.empty?
           $stderr.puts 'No templates found'
         else
-          base = Pathname.new(cluster.template(ext: false))
-          list.each do |path|
-            puts Pathname.new(path).relative_path_from(base).to_s
-                         .chomp("#{Config.template_ext}")
-          end
+          puts list.human_paths
         end
       end
 
@@ -79,8 +74,23 @@ module Cloudware
           new(Cluster.load(cluster_name))
         end
 
+        def base
+          cluster.template(ext: false)
+        end
+
+        ##
+        # These represent the valid template CLI inputs
+        #
+        def human_paths
+          templates.map do |path|
+            path.relative_path_from(base).sub_ext('')
+          end
+        end
+
         def templates
-          @templates ||= Dir.glob(cluster.template('**/*')).sort
+          @templates ||= Dir.glob(cluster.template('**/*'))
+                            .sort
+                            .map { |p| Pathname.new(p) }
         end
       end
 

--- a/lib/cloudware/commands/cluster.rb
+++ b/lib/cloudware/commands/cluster.rb
@@ -57,12 +57,11 @@ module Cloudware
       def list_templates
         list = ListTemplates.build(__config__.current_cluster)
         cluster = Cluster.load(__config__.current_cluster)
-        templates = Dir.glob(cluster.template('**/*')).sort
-        if templates.empty?
+        if list.templates.empty?
           $stderr.puts 'No templates found'
         else
           base = Pathname.new(cluster.template(ext: false))
-          templates.each do |path|
+          list.each do |path|
             puts Pathname.new(path).relative_path_from(base).to_s
                          .chomp("#{Config.template_ext}")
           end
@@ -72,8 +71,16 @@ module Cloudware
       private
 
       ListTemplates = Struct.new(:cluster) do
+        include Enumerable
+
+        delegate :each, to: :templates
+
         def self.build(cluster_name)
           new(Cluster.load(cluster_name))
+        end
+
+        def templates
+          @templates ||= Dir.glob(cluster.template('**/*')).sort
         end
       end
 

--- a/lib/cloudware/commands/cluster.rb
+++ b/lib/cloudware/commands/cluster.rb
@@ -54,58 +54,7 @@ module Cloudware
         puts _render(LIST_CLUSTERS)
       end
 
-      def list_templates(verbose: false)
-        list = ListTemplates.build(__config__.current_cluster)
-        if list.templates.empty?
-          $stderr.puts 'No templates found'
-        else
-          list.human_paths.each do |human_path, abs_path|
-            print human_path
-            print " => #{abs_path}" if verbose
-            puts
-          end
-        end
-      end
-
       private
-
-      ListTemplates = Struct.new(:cluster) do
-        include Enumerable
-
-        delegate :each, to: :templates
-
-        def self.build(cluster_name)
-          new(Cluster.load(cluster_name))
-        end
-
-        def base
-          cluster.template(ext: false)
-        end
-
-        ##
-        # These represent the valid template CLI inputs
-        #
-        def human_paths
-          templates.map do |template|
-            name = template.basename.sub_ext('')
-            dir_name = template.dirname.basename
-            alternate = template.dirname.dirname.join(template.basename)
-
-            # Detect shorthand enabled templates
-            shorthand = (name == dir_name && !alternate.file?)
-            relative = template.dirname.relative_path_from(base)
-
-            human_path = shorthand ? relative : File.join(relative, name)
-            [human_path, template]
-          end.to_h
-        end
-
-        def templates
-          @templates ||= Dir.glob(cluster.template('**/*'))
-                            .sort
-                            .map { |p| Pathname.new(p) }
-        end
-      end
 
       def clusters
         Dir.glob(Cluster.new('*').directory)

--- a/lib/cloudware/commands/cluster.rb
+++ b/lib/cloudware/commands/cluster.rb
@@ -54,13 +54,15 @@ module Cloudware
         puts _render(LIST_CLUSTERS)
       end
 
-      def list_templates
+      def list_templates(verbose: false)
         list = ListTemplates.build(__config__.current_cluster)
         if list.templates.empty?
           $stderr.puts 'No templates found'
         else
-          list.human_paths.each do |path, shorthand|
-            puts shorthand || path
+          list.human_paths.each do |human_path, abs_path|
+            print human_path
+            print " => #{abs_path}" if verbose
+            puts
           end
         end
       end
@@ -88,12 +90,13 @@ module Cloudware
             name = template.basename.sub_ext('')
             dir_name = template.dirname.basename
             alternate = template.dirname.dirname.join(template.basename)
-            relative_base = template.dirname.relative_path_from(base)
 
             # Detect shorthand enabled templates
             shorthand = (name == dir_name && !alternate.file?)
+            relative = template.dirname.relative_path_from(base)
 
-            [File.join(relative_base, name), shorthand ? relative_base : nil]
+            human_path = shorthand ? relative : File.join(relative, name)
+            [human_path, template]
           end.to_h
         end
 

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -31,6 +31,7 @@ module Cloudware
   module Commands
     class ClusterCommand < Command
       LIST_CLUSTERS = <<~ERB
+        <% clusters = load_clusters -%>
         <% unless clusters.include?(__config__.current_cluster) -%>
         * <%= __config__.current_cluster %>
         <% end -%>
@@ -53,8 +54,8 @@ module Cloudware
 
       private
 
-      def clusters
-        Dir.glob(Cluster.new('*').directory)
+      def load_clusters
+        Dir.glob(Cluster.new('*').join)
            .map { |p| File.basename(p) }
            .sort
       end

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -29,7 +29,7 @@ require 'pathname'
 
 module Cloudware
   module Commands
-    class ClusterCmd < Command
+    class ClusterCommand < Command
       LIST_CLUSTERS = <<~ERB
         <% unless clusters.include?(__config__.current_cluster) -%>
         * <%= __config__.current_cluster %>

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -40,9 +40,6 @@ module Cloudware
         <% end -%>
       ERB
 
-      LIST_TEMPLATES = <<~ERB
-      ERB
-
       def switch(cluster)
         @__config__ = CommandConfig.update do |conf|
           conf.current_cluster = cluster

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -42,6 +42,7 @@ module Cloudware
       ERB
 
       def switch(cluster)
+        error_if_missing(cluster, action: 'switch')
         @__config__ = CommandConfig.update do |conf|
           conf.current_cluster = cluster
         end
@@ -58,6 +59,13 @@ module Cloudware
         Dir.glob(Cluster.new('*').join)
            .map { |p| File.basename(p) }
            .sort
+      end
+
+      def error_if_missing(cluster, action:)
+        return if load_clusters.include?(cluster)
+        raise InvalidInput, <<~ERROR.chomp
+          Failed to #{action} cluster. '#{cluster}' doesn't exist
+        ERROR
       end
     end
   end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -53,11 +53,13 @@ module Cloudware
         list = build_template_list
         if list.templates.empty?
           $stderr.puts 'No templates found'
-        else
+        elsif verbose
           list.human_paths.each do |human_path, abs_path|
-            print human_path
-            print " => #{abs_path}" if verbose
-            puts
+            puts "#{human_path} => #{abs_path}"
+          end
+        else
+          list.shorthand_paths.each do |human_path, _|
+            puts human_path
           end
         end
       end
@@ -100,12 +102,22 @@ module Cloudware
             # Adds the shorthand path (if available)
             # The directory must not have a sibling template of the same name
             if (name == directory.basename) && !directory_file.file?
-              memo[directory.relative_path_from(base)] = template
+              memo[directory.relative_path_from(base).to_s] = template
             end
 
             # Adds the standard path
-            memo[long_name.relative_path_from(base)] = template
+            memo[long_name.relative_path_from(base).to_s] = template
           end
+        end
+
+        def shorthand_paths
+          human_paths.each_with_object({}) do |(name, path), memo|
+            if memo.key?(path)
+              memo[path] = name if memo[path].length > name.length
+            else
+              memo[path] = name
+            end
+          end.map { |v, k| [k, v] }.to_h
         end
 
         def templates

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -48,14 +48,16 @@ module Cloudware
       attr_reader :name, :raw_path
 
       def template_path
-        if raw_path.absolute?
-          raw_path.to_s
-        else
-          Cluster.load(__config__.current_cluster).template(raw_path.to_s)
-        end
+        return raw_path if raw_path.absolute?
+        cluster = Cluster.load(__config__.current_cluster)
+        path = cluster.template(raw_path)
+        nested_path = cluster.template(raw_path, path.basename, ext: false)
+        return nested_path if !path.file? && nested_path.file?
+        path
       end
 
       def deployment
+        puts "Deploying: #{template_path}"
         Models::Deployment.new(
           template_path: template_path,
           name: name,

--- a/lib/cloudware/commands/import.rb
+++ b/lib/cloudware/commands/import.rb
@@ -33,7 +33,7 @@ module Cloudware
       def run!(raw_path)
         zip_path = Pathname.new(raw_path).expand_path.sub_ext('.zip').to_s
         cluster = Cluster.load(__config__.current_cluster)
-        Zip::File.open(zip_path) do |zip|
+        ZipImporter.extract(zip_path) do |zip|
           zip.glob('aws/**/*').reject(&:directory?).each do |file|
             dst = Pathname.new(file.name)
                           .sub(/\Aaws\//, '')
@@ -47,6 +47,18 @@ module Cloudware
             end
           end
         end
+      end
+
+      private
+
+      ZipImporter = Struct.new(:zip_file) do
+        def self.extract(path)
+          Zip::File.open(path) do |f|
+            yield new(f) if block_given?
+          end
+        end
+
+        delegate_missing_to :zip_file
       end
     end
   end

--- a/lib/cloudware/commands/import.rb
+++ b/lib/cloudware/commands/import.rb
@@ -40,6 +40,8 @@ module Cloudware
       private
 
       ZipImporter = Struct.new(:zip_file) do
+        TEMPLATE_GLOB = 'aws/{domain,{group,node}/*}/platform/templates/**/*'
+
         delegate_missing_to :zip_file
 
         def self.extract(path)
@@ -62,15 +64,14 @@ module Cloudware
             if dst.exist?
               $stderr.puts "Skipping, file already exists: #{dst}"
             else
-              extract(dst)
+              zip_src.extract(dst)
               puts "Imported: #{dst}"
             end
           end
         end
 
         def templates
-          glob_path = 'aws/{domain,{group,node}/*}/platform/templates/**/*'
-          glob(glob_path).reject(&:directory?)
+          glob(TEMPLATE_GLOB).reject(&:directory?)
         end
       end
     end

--- a/lib/cloudware/commands/import.rb
+++ b/lib/cloudware/commands/import.rb
@@ -48,11 +48,16 @@ module Cloudware
           end
         end
 
+        def self.dst_template_path(src, base)
+          Pathname.new(src)
+                  .sub(/\Aaws\//, '')
+                  .expand_path(base)
+        end
+
         def copy_templates(cluster)
-          cluster = Cluster.load(cluster)
+          base = Cluster.load(cluster).template(ext: false)
           templates.each do |zip_src|
-            dst = Pathname.new(zip_src.name).sub(/\Aaws\//, '')
-                          .expand_path(cluster.template(ext: false))
+            dst = self.class.dst_template_path(zip_src.name, base)
             dst.dirname.mkpath
             if dst.exist?
               $stderr.puts "Skipping, file already exists: #{dst}"


### PR DESCRIPTION
Templates are now only imported from the following locations within the `zip` file:
`{domain,{group,node}/*}/platform/templates/**/*`

Only the `platform/templates` directory is imported to allow room for other file types within the `zip` file. This makes the exporting from `underware` a bit easier.

Once the templates are imported, they can be deployed by giving there relative path from the `templates` directory without the file extension. However, it there is a tautology (e.g. `domain/domain.yaml`), then only the first part (`domain`) is required.

The above shorthand only works if the paths are unambiguous. From a usability point of view, the valid imports are returned from `list templates [--verbose]`