### PR TITLE
Manually define the subcommand groups

### DIFF
--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -78,7 +78,6 @@ module Cloudware
 
     def self.cli_syntax(command, args_str = '')
       command.hidden = true if command.name.split.length > 1
-      command.sub_command_group = true
       command.syntax = <<~SYNTAX.squish
         #{program(:name)} #{command.name} #{args_str} [options]
       SYNTAX
@@ -90,6 +89,7 @@ module Cloudware
 
     command 'cluster' do |c|
       cli_syntax(c)
+      c.sub_command_group = true
       c.summary = 'Manage the current cluster selection'
     end
 
@@ -158,6 +158,7 @@ module Cloudware
 
     command 'list' do |c|
       cli_syntax(c)
+      c.sub_command_group = true
       c.summary = 'List the deployed cloud resources'
     end
 
@@ -210,6 +211,7 @@ module Cloudware
 
     command 'power' do |c|
       cli_syntax(c)
+      c.sub_command_group = true
       c.description = 'Start or stop machine and check their power status'
     end
 

--- a/lib/cloudware/context.rb
+++ b/lib/cloudware/context.rb
@@ -131,7 +131,7 @@ module Cloudware
     end
 
     def path
-      Cluster.load(cluster).join('var/contexts.yaml')
+      Cluster.load(cluster || '').join('var/contexts.yaml')
              .tap { |p| FileUtils.mkdir_p(File.dirname(p)) }
     end
   end

--- a/spec/cloudware/context_spec.rb
+++ b/spec/cloudware/context_spec.rb
@@ -27,8 +27,11 @@
 require 'cloudware/context'
 
 RSpec.describe Cloudware::Context do
+  let(:cluster) { 'test-cluster' }
+
   subject do
-    build(:context).tap { |c| c.save_deployments(*deployments) }
+    described_class.new(cluster: cluster)
+                   .tap { |c| c.save_deployments(*deployments) }
   end
 
   def new_context
@@ -139,7 +142,7 @@ RSpec.describe Cloudware::Context do
       build(:deployment, name: 'other-deployment')
     end
     let(:other_context) do
-      described_class.new(region: subject.region, cluster: Cloudware::CommandConfig.new.current_cluster)
+      described_class.new(cluster: cluster)
     end
 
     # Ensure the other context/deployment are created after the subject

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -24,6 +24,8 @@
 # ==============================================================================
 #
 
+require 'cloudware/models'
+
 FactoryBot.define do
   models = Cloudware::Models
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,16 @@ require 'factory_bot'
 
 SPEC_DIR = __dir__
 
+module FakeFS
+  class Pathname
+    def to_str
+      self.to_s
+    end
+
+    delegate_missing_to :to_str
+  end
+end
+
 RSpec.configure do |config|
   config.include FakeFS::SpecHelpers::All
   config.include FactoryBot::Syntax::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ require 'rubygems'
 require 'bundler'
 
 Bundler.setup(:default, :config, :development)
+ENV['CLOUDWARE_PROVIDER'] = 'aws'
 require File.join(File.dirname(__FILE__), '../lib/cloudware')
 
 require 'rspec/wait'
@@ -38,7 +39,6 @@ require 'fakefs/spec_helpers'
 require 'factory_bot'
 
 SPEC_DIR = __dir__
-ENV['CLOUDWARE_PROVIDER'] = 'aws'
 
 RSpec.configure do |config|
   config.include FakeFS::SpecHelpers::All


### PR DESCRIPTION
This was the first attempt at making the command definitions at bit easier to maintain. However to fix the issue correctly, a different help template is required. This will require fixes to `Commander` before it can be rolled out into the applications.

For the time being, the sub commands need to be defined manually. 