### PR TITLE
Clean up the path definitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: 800db4549fa5c8e78c45c86bc0122c3f73b3be8c
+  revision: 19cd6fa00f3594d7f7bcaad9d63ade74bdba6cfc
   specs:
     flight_config (0.1.0)
       tty-config

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: 44d7e1c93f1b2b659541cb4a0bbd192301d7b70c
+  revision: 209772e1110e5c18f2d1156b44dd0295ab82f178
   specs:
     flight_config (0.1.0)
       tty-config

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: 19cd6fa00f3594d7f7bcaad9d63ade74bdba6cfc
+  revision: 44d7e1c93f1b2b659541cb4a0bbd192301d7b70c
   specs:
     flight_config (0.1.0)
       tty-config

--- a/etc/config.yaml.example
+++ b/etc/config.yaml.example
@@ -23,7 +23,6 @@ aws:                            # Requirement for cloud-aws
 
 # ADVANCED CONFIGURATION (Optional)
 # =============================================================================
-# and renamed: "etc/config.yaml"
 # Content Directory
 # By default cloudware stores its content within the <install-dir>/var
 # directory. This can be optionally changed to a different location
@@ -32,11 +31,11 @@ aws:                            # Requirement for cloud-aws
 
 # =============================================================================
 # LOG FILE
-# By default cloudware log into <install-dir>/log/cloudware.log file. It does
+# By default cloudware log into <install-dir>/log directory. It does
 # not setup log rotations on the file. Cloudware can be configured to log
 # somewhere else with the `log_file` key
 # =============================================================================
-# log_file:
+# log_directory:
 
 # =============================================================================
 # STATIC PROVIDER

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -27,6 +27,7 @@
 require 'commander'
 
 require 'cloudware/command'
+require 'cloudware/log'
 require 'cloudware/version'
 
 require 'require_all'

--- a/lib/cloudware/cluster.rb
+++ b/lib/cloudware/cluster.rb
@@ -46,11 +46,6 @@ module Cloudware
       join('etc/config.yaml')
     end
 
-    def template(*parts, ext: true)
-      path = join('lib', 'templates', *parts)
-      ext ? path.sub_ext(Config.template_ext) : path
-    end
-
     def region
       __data__.fetch(:region) { Config.default_region }
     end

--- a/lib/cloudware/cluster.rb
+++ b/lib/cloudware/cluster.rb
@@ -38,12 +38,8 @@ module Cloudware
       @identifier = identifier
     end
 
-    def join(*paths)
-      Pathname.new(RootDir.content_cluster(identifier, *paths))
-    end
-
     def path
-      join('etc/config.yaml')
+      RootDir.content_cluster(identifier, 'etc/config.yaml')
     end
 
     def region

--- a/lib/cloudware/cluster.rb
+++ b/lib/cloudware/cluster.rb
@@ -24,7 +24,7 @@
 # ==============================================================================
 #
 
-require 'cloudware/root_paths'
+require 'cloudware/root_dir'
 
 module Cloudware
   class Cluster
@@ -39,16 +39,11 @@ module Cloudware
     end
 
     def join(*paths)
-      Pathname.new(Config.content('clusters', identifier, *paths))
-    end
-
-    # Deprecated! Use `join` instead
-    def directory
-      join()
+      Pathname.new(RootDir.content_cluster(identifier, *paths))
     end
 
     def path
-      RootPaths.cluster('etc/config.yaml')
+      join('etc/config.yaml')
     end
 
     def template(*parts, ext: true)

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -37,7 +37,7 @@ module Cloudware
     attr_reader :__config__
 
     def initialize(__config__ = nil)
-      @__config__ = __config__ || CommandConfig.load
+      @__config__ = __config__ || CommandConfig.read
     end
 
     def run!(*argv, **options)

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -32,7 +32,7 @@ module Cloudware
   module Commands
     class ClusterCommand < Command
       LIST_CLUSTERS = <<~ERB
-        <% clusters = load_clusters -%>
+        <% clusters = read_clusters -%>
         <% unless clusters.include?(__config__.current_cluster) -%>
         * <%= __config__.current_cluster %>
         <% end -%>
@@ -45,7 +45,7 @@ module Cloudware
       def init(cluster, import: nil)
         error_if_exists(cluster, action: 'create')
         update_cluster(cluster)
-        FileUtils.mkdir_p File.dirname(Cluster.load(cluster).path)
+        FileUtils.mkdir_p File.dirname(Cluster.read(cluster).path)
         Import.new(__config__).run!(import) if import
         puts "Created cluster: #{cluster}"
       end
@@ -68,21 +68,21 @@ module Cloudware
         end
       end
 
-      def load_clusters
+      def read_clusters
         Dir.glob(Cluster.new('*').join)
            .map { |p| File.basename(p) }
            .sort
       end
 
       def error_if_exists(cluster, action:)
-        return unless load_clusters.include?(cluster)
+        return unless read_clusters.include?(cluster)
         raise InvalidInput, <<~ERROR.chomp
           Failed to #{action} cluster. '#{cluster}' already exists
         ERROR
       end
 
       def error_if_missing(cluster, action:)
-        return if load_clusters.include?(cluster)
+        return if read_clusters.include?(cluster)
         raise InvalidInput, <<~ERROR.chomp
           Failed to #{action} cluster. '#{cluster}' doesn't exist
         ERROR

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -69,7 +69,7 @@ module Cloudware
       end
 
       def read_clusters
-        Dir.glob(Cluster.new('*').join)
+        Dir.glob(Cluster.new('*').path)
            .map { |p| File.basename(p) }
            .sort
       end

--- a/lib/cloudware/commands/concerns/markdown_template.rb
+++ b/lib/cloudware/commands/concerns/markdown_template.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'cloudware/models/deployments'
 require 'tty-color'
 require 'tty-markdown'
 
@@ -13,6 +14,10 @@ module Cloudware
 
           def cluster
             @cluster ||= Cluster.read(cluster_identifier)
+          end
+
+          def deployments
+            @deployments ||= Models::Deployments.read(cluster_identifier)
           end
 
           def render(template, verbose: false)

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -96,8 +96,16 @@ module Cloudware
           new(Cluster.load(cluster_name))
         end
 
+        def template_path(*parts, ext: true)
+          path = RootDir.content_cluster(cluster.identifier,
+                                         'lib/templates',
+                                         *parts)
+          path = Pathname.new(path)
+          ext ? path.sub_ext(Config.template_ext) : path
+        end
+
         def base
-          cluster.template(ext: false)
+          template_path(ext: false)
         end
 
         ##
@@ -132,7 +140,7 @@ module Cloudware
         end
 
         def templates
-          @templates ||= Dir.glob(cluster.template('**/*'))
+          @templates ||= Dir.glob(template_path('**/*'))
                             .sort
                             .map { |p| Pathname.new(p) }
         end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -84,7 +84,7 @@ module Cloudware
       end
 
       def build_template_list
-        ListTemplates.build(__config__.current_cluster)
+        ListTemplates.new(__config__.current_cluster)
       end
 
       ListTemplates = Struct.new(:cluster) do
@@ -92,12 +92,8 @@ module Cloudware
 
         delegate :each, to: :templates
 
-        def self.build(cluster_name)
-          new(Cluster.load(cluster_name))
-        end
-
         def template_path(*parts, ext: true)
-          path = RootDir.content_cluster(cluster.identifier,
+          path = RootDir.content_cluster(cluster,
                                          'lib/templates',
                                          *parts)
           path = Pathname.new(path)

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -93,9 +93,7 @@ module Cloudware
         delegate :each, to: :templates
 
         def template_path(*parts, ext: true)
-          path = RootDir.content_cluster(cluster,
-                                         'lib/templates',
-                                         *parts)
+          path = RootDir.content_cluster_template(cluster, *parts)
           path = Pathname.new(path)
           ext ? path.sub_ext(Config.template_ext) : path
         end

--- a/lib/cloudware/commands/import.rb
+++ b/lib/cloudware/commands/import.rb
@@ -65,7 +65,7 @@ module Cloudware
         end
 
         def copy_templates(cluster)
-          base = Cluster.read(cluster).template(ext: false)
+          base = RootDir.content_cluster_template(cluster, nil)
           templates.each do |zip_src|
             dst = self.class.dst_template_path(zip_src.name, base)
             dst.dirname.mkpath

--- a/lib/cloudware/commands/import.rb
+++ b/lib/cloudware/commands/import.rb
@@ -65,7 +65,7 @@ module Cloudware
         end
 
         def copy_templates(cluster)
-          base = Cluster.load(cluster).template(ext: false)
+          base = Cluster.read(cluster).template(ext: false)
           templates.each do |zip_src|
             dst = self.class.dst_template_path(zip_src.name, base)
             dst.dirname.mkpath

--- a/lib/cloudware/commands/import.rb
+++ b/lib/cloudware/commands/import.rb
@@ -65,7 +65,7 @@ module Cloudware
         end
 
         def copy_templates(cluster)
-          base = RootDir.content_cluster_template(cluster, nil)
+          base = RootDir.content_cluster_template(cluster)
           templates.each do |zip_src|
             dst = self.class.dst_template_path(zip_src.name, base)
             dst.dirname.mkpath

--- a/lib/cloudware/commands/lists/deployment.rb
+++ b/lib/cloudware/commands/lists/deployment.rb
@@ -45,6 +45,7 @@ module Cloudware
           <% end -%>
           *Creation Date*: <%= deployment.timestamp %>
           *Template*: <%= deployment.template_path %>
+          *Provider Tag*: <%= deployment.tag %>
 
           ## Results
           <% if deployment.results.nil? || deployment.results.empty? -%>

--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -43,7 +43,7 @@ module Cloudware
 
         def machines
           if options.group
-            Cluster.load(__config__.current_cluster)
+            Cluster.read(__config__.current_cluster)
                    .deployments
                    .machines
                    .select { |m| m.groups.include?(identifier) }

--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -43,10 +43,9 @@ module Cloudware
 
         def machines
           if options.group
-            Cluster.read(__config__.current_cluster)
-                   .deployments
-                   .machines
-                   .select { |m| m.groups.include?(identifier) }
+            Deployments.read(__config__.current_cluster)
+                       .machines
+                       .select { |m| m.groups.include?(identifier) }
           else
             [Models::Machine.new(name: identifier, cluster: __config__.current_cluster)]
           end

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -56,11 +56,10 @@ module Cloudware
     end
 
     def log_file
-      __data__.fetch(:log_file) do
-        File.join(self.class.root_dir, 'log', "#{provider}.log").tap do |path|
-          FileUtils.mkdir_p(File.dirname(path))
-        end
+      dir = __data__.fetch(:log_directory) do
+        File.join(self.class.root_dir, 'log').tap { |d| FileUtils.mkdir_p(d) }
       end
+      File.join(dir, provider + '.log')
     end
 
     def provider

--- a/lib/cloudware/log.rb
+++ b/lib/cloudware/log.rb
@@ -41,4 +41,7 @@ module Cloudware
       delegate_missing_to :instance
     end
   end
+
+  Config.cache
+  FlightConfig.logger = Log
 end

--- a/lib/cloudware/log.rb
+++ b/lib/cloudware/log.rb
@@ -30,15 +30,15 @@ require 'logger'
 module Cloudware
   class Log
     class << self
-      def cache
-        @cache ||= Logger.new(path)
+      def instance
+        @instance ||= Logger.new(path)
       end
 
       def path
         Config.log_file
       end
 
-      delegate_missing_to :cache
+      delegate_missing_to :instance
     end
   end
 end

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -110,9 +110,9 @@ module Cloudware
       end
 
       def region
-        # Protect the load from a `nil` cluster. There is a separate validation
+        # Protect the read from a `nil` cluster. There is a separate validation
         # for nil clusters
-        Cluster.load(cluster.to_s).region
+        Cluster.read(cluster.to_s).region
       end
 
       def <=>(other)

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -28,7 +28,7 @@ require 'cloudware/models/deployment_callbacks'
 require 'cloudware/models/concerns/provider_client'
 require 'cloudware/models/application'
 require 'cloudware/models/machine'
-require 'cloudware/root_paths'
+require 'cloudware/root_dir'
 
 require 'pathname'
 require 'time'
@@ -75,7 +75,7 @@ module Cloudware
       end
 
       def path
-        RootPaths.cluster(cluster.to_s, 'var/deployments', name + '.yaml')
+        RootDir.content_cluster(cluster.to_s, 'var/deployments', name + '.yaml')
       end
 
       def template

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -28,6 +28,8 @@ require 'cloudware/models/deployment_callbacks'
 require 'cloudware/models/concerns/provider_client'
 require 'cloudware/models/application'
 require 'cloudware/models/machine'
+require 'cloudware/root_paths'
+
 require 'pathname'
 require 'time'
 
@@ -73,7 +75,7 @@ module Cloudware
       end
 
       def path
-        Cluster.load(cluster.to_s).join('var/deployments', name + '.yaml')
+        RootPaths.cluster(cluster.to_s, 'var/deployments', name + '.yaml')
       end
 
       def template

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -129,6 +129,10 @@ module Cloudware
         Time.at(epoch_time)
       end
 
+      def tag
+        "cloudware-#{name}-#{random_tag}"
+      end
+
       private
 
       def run_deploy
@@ -158,10 +162,6 @@ module Cloudware
           <% end -%>
           <% end -%>
         TEMPLATE
-      end
-
-      def tag
-        "cloudware-#{name}-#{random_tag}"
       end
 
       def raw_template

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -65,6 +65,11 @@ module Cloudware
         end
       end
 
+      def random_tag
+        __data__.set_if_empty(:random_tag, value: rand(1000000))
+        __data__.fetch(:random_tag)
+      end
+
       def results
         __data__.fetch(:results, default: {}).deep_symbolize_keys
       end
@@ -156,7 +161,7 @@ module Cloudware
       end
 
       def tag
-        "cloudware-deploy-#{name}"
+        "cloudware-#{name}-#{random_tag}"
       end
 
       def raw_template

--- a/lib/cloudware/root_dir.rb
+++ b/lib/cloudware/root_dir.rb
@@ -35,15 +35,29 @@ require 'cloudware/config'
 #
 # When adding a new path, make sure name maps to the arguments!
 #
+# NOTE: Optional: [last_named_argument]
+# The last named argument to these methods should be optional, so calling it
+# without arguments gives the directory. e.g.
+#
+# content_cluster()             => .../clusters
+# content_cluster('my-cluster)  => .../clusters/my-cluster
+#
+# It is however required for all dependent method calls. e.g:
+# content_cluster_template(cluster, [template])
+#
 
 module Cloudware
   class RootDir
-    def self.content(*a)
-      File.join(Config.content_path, *a)
+    def self.content(*parts)
+      File.join(Config.content_path, *parts)
     end
 
-    def self.content_cluster(cluster, *a)
-      content('clusters', cluster, *a)
+    def self.content_cluster(*a) # [cluster]
+      content('clusters', *a)
+    end
+
+    def self.content_cluster_template(cluster, *a) # [template]
+      content_cluster(cluster, 'lib/templates', *a)
     end
   end
 end

--- a/lib/cloudware/root_dir.rb
+++ b/lib/cloudware/root_dir.rb
@@ -39,7 +39,7 @@ require 'cloudware/config'
 module Cloudware
   class RootDir
     def self.content(*a)
-      File.join(Config.content_path, Config.provider, *a)
+      File.join(Config.content_path, *a)
     end
 
     def self.content_cluster(cluster, *a)

--- a/lib/cloudware/root_dir.rb
+++ b/lib/cloudware/root_dir.rb
@@ -37,13 +37,13 @@ require 'cloudware/config'
 #
 
 module Cloudware
-  class RootPaths
-    def self.join(*a)
+  class RootDir
+    def self.content(*a)
       File.join(Config.content_path, Config.provider, *a)
     end
 
-    def self.cluster(cluster, *a)
-      join('clusters', cluster, *a)
+    def self.content_cluster(cluster, *a)
+      content('clusters', cluster, *a)
     end
   end
 end

--- a/lib/cloudware/root_paths.rb
+++ b/lib/cloudware/root_paths.rb
@@ -2,7 +2,7 @@
 
 #
 # =============================================================================
-# Copyright (C) 2019 Stephen F. Norledge and Alces Flight Ltd
+# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd
 #
 # This file is part of Alces Cloudware.
 #
@@ -24,44 +24,26 @@
 # ==============================================================================
 #
 
-require 'cloudware/root_paths'
+require 'cloudware/config'
+
+#
+# NOTE: To future maintainer!
+#
+# Please keep this file as lean as possible. It is design to contain the root
+# path definition between different types of files. It should not contain the
+# path definition for an individual file.
+#
+# When adding a new path, make sure name maps to the arguments!
+#
 
 module Cloudware
-  class Cluster
-    include FlightConfig::Loader
-
-    delegate :provider, to: Config
-
-    attr_reader :identifier
-
-    def initialize(identifier)
-      @identifier = identifier
+  class RootPaths
+    def self.join(*a)
+      File.join(Config.content_path, Config.provider, *a)
     end
 
-    def join(*paths)
-      Pathname.new(Config.content('clusters', identifier, *paths))
-    end
-
-    # Deprecated! Use `join` instead
-    def directory
-      join()
-    end
-
-    def path
-      RootPaths.cluster('etc/config.yaml')
-    end
-
-    def template(*parts, ext: true)
-      path = join('lib', 'templates', *parts)
-      ext ? path.sub_ext(Config.template_ext) : path
-    end
-
-    def region
-      __data__.fetch(:region) { Config.default_region }
-    end
-
-    def deployments
-      Models::Deployments.read(identifier)
+    def self.cluster(cluster, *a)
+      join('clusters', cluster, *a)
     end
   end
 end


### PR DESCRIPTION
Fixes #194

This PR defines the root directory paths in a new `RootDir` module. This allows each object to define their own path without having to load the `Cluster`. This and a few other changes have cut down the file reads.

It also updates to the latest version of `FlightConfig` which currently handles file locking/ creation/ deletion. Finally all stacks have a random tag appended to them to reduce the risk of collisions.