### PR TITLE
Various minor features and changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,5 @@ group :development do
   gem 'rspec-wait'
   gem 'rubocop', '~> 0.52.1', require: false
   gem 'rubocop-rspec'
+  gem 'ruby-prof'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -33,11 +33,12 @@ end
 group :development do
   gem 'factory_bot'
   gem 'fakefs'
+  gem 'pilfer'
   gem 'pry'
   gem 'pry-byebug'
+  gem 'rake'
   gem 'rspec'
   gem 'rspec-wait'
   gem 'rubocop', '~> 0.52.1', require: false
   gem 'rubocop-rspec'
-  gem 'ruby-prof'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-rspec (1.23.0)
       rubocop (>= 0.52.1)
+    ruby-prof (0.17.0)
     ruby-progressbar (1.9.0)
     rubyzip (1.2.2)
     strings (0.1.1)
@@ -178,6 +179,7 @@ DEPENDENCIES
   rspec-wait
   rubocop (~> 0.52.1)
   rubocop-rspec
+  ruby-prof
   rubyzip
   tty-markdown
   tty-spinner

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: 209772e1110e5c18f2d1156b44dd0295ab82f178
+  revision: 770cd15de6dfde4971ddc541548187c4b92f599d
   specs:
     flight_config (0.1.0)
       tty-config

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     coderay (1.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
+    debugger-ruby_core_source (1.3.8)
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
@@ -84,6 +85,8 @@ GEM
     pastel (0.7.2)
       equatable (~> 0.5.0)
       tty-color (~> 0.4.0)
+    pilfer (1.0.2)
+      rblineprof (~> 0.3.2)
     powerpack (0.1.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -92,6 +95,9 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     rainbow (3.0.0)
+    rake (12.3.2)
+    rblineprof (0.3.7)
+      debugger-ruby_core_source (~> 1.3)
     require_all (2.0.0)
     rouge (3.1.1)
     rspec (3.7.0)
@@ -118,7 +124,6 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-rspec (1.23.0)
       rubocop (>= 0.52.1)
-    ruby-prof (0.17.0)
     ruby-progressbar (1.9.0)
     rubyzip (1.2.2)
     strings (0.1.1)
@@ -172,14 +177,15 @@ DEPENDENCIES
   ipaddr
   memoist
   parallel
+  pilfer
   pry
   pry-byebug
+  rake
   require_all
   rspec
   rspec-wait
   rubocop (~> 0.52.1)
   rubocop-rspec
-  ruby-prof
   rubyzip
   tty-markdown
   tty-spinner

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: 770cd15de6dfde4971ddc541548187c4b92f599d
+  revision: 6710c22291f1733ae029a2898993b3ab77a9787b
   specs:
     flight_config (0.1.0)
       tty-config

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ If a however a different domain was used which returned the key as
 case, the key can be translated by:
 `securitygroup=*my-other-domain.othersecuritygroup`
 
+*Deployment Results (Advanced Cont.):* `key1,key2=*my-domain`
+
+This will replace `key1` and `key2` from `my-domain`. It is equivalent to:
+`'key1=*my-domain key2=*my-domain`
+
 ### Native Provider Parameters
 Both `aws` and `azure` natively support parameters within the templates.
 However in order to provide a generalised mechanism, these native parameters

--- a/Rakefile
+++ b/Rakefile
@@ -42,8 +42,10 @@ task :profile do
   profiler = Pilfer::Profiler.new(reporter)
 
   $LOAD_PATH << File.join(__dir__, 'lib')
+  ARGV = []
   profiler.profile('require') do
     require 'cloudware'
+    Cloudware::CLI.run!
   end
 
   io.rewind

--- a/Rakefile
+++ b/Rakefile
@@ -32,3 +32,20 @@ task :spin do
   end
   puts result
 end
+
+task :profile do
+  Bundler.setup(:development)
+  require 'pilfer'
+
+  io = StringIO.new
+  reporter = Pilfer::Logger.new(io)
+  profiler = Pilfer::Profiler.new(reporter)
+
+  $LOAD_PATH << File.join(__dir__, 'lib')
+  profiler.profile('require') do
+    require 'cloudware'
+  end
+
+  io.rewind
+  puts io.read
+end

--- a/bin/cloud
+++ b/bin/cloud
@@ -53,7 +53,7 @@ begin
   Bundler.setup(:config, :default, Cloudware::Config.provider)
 
   require 'cloudware'
-rescue Cloudware::ConfigError => e
+rescue => e
   $stderr.puts e.message
   exit 1
 end

--- a/bin/cloud
+++ b/bin/cloud
@@ -37,7 +37,7 @@ require 'bundler'
 # Catch any config errors during the require/setup
 begin
   # Require the config and associated gems
-  Bundler.require(:config)
+  Bundler.setup(:config)
   require 'cloudware/config'
 
   # Require the development gems
@@ -50,7 +50,7 @@ begin
   end
 
   # Setup the load path for remaining gems
-  Bundler.setup(:default, Cloudware::Config.provider)
+  Bundler.setup(:config, :default, Cloudware::Config.provider)
 
   require 'cloudware'
 rescue Cloudware::ConfigError => e

--- a/etc/config.yaml.example
+++ b/etc/config.yaml.example
@@ -8,6 +8,10 @@
 # for details.
 # =============================================================================
 
+# The deployments name on the provider will be appended with this tag. This
+# should be unique for this install of cloudware
+append_tag: # REQUIRED
+
 # Provider credentials
 azure:                        # Requirement for cloud-azure
   default_region:   # [VALUE] : Requirement for cloud-azure

--- a/etc/config.yaml.travis
+++ b/etc/config.yaml.travis
@@ -11,3 +11,4 @@ aws:                            # Requirement for cloud-aws
   secret_access_key:  # [VALUE] : Requirement for cloud-aws
 
 log_file: /tmp/travis.log
+append_tag: travis

--- a/lib/cloudware.rb
+++ b/lib/cloudware.rb
@@ -24,8 +24,8 @@
 # ==============================================================================
 #
 
-# ActiveSupport modules
-require 'active_support/core_ext/string'
+require 'active_support/core_ext/string/strip'
+require 'active_support/core_ext/string/filters'
 
 require 'cloudware/config'
 require 'cloudware/cli'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -248,15 +248,15 @@ module Cloudware
     end
 
     command 'render' do |c|
-      cli_syntax(c, 'NAME')
-      c.summary = 'Render a template for an existing or new deployment'
+      cli_syntax(c, 'NAME [TEMPLATE]')
+      c.summary = 'Return the template for an existing or new deployment'
       c.description = <<~DESC
         Renders the template for the `NAME` deployment. Existing deployments
-        will always render the saved template path and replacements.
+        will always render the saved template and replacements.
 
-        If the template does not exist, the `--template` and `--params`
+        If the deployment does not exist, the `TEMPLATE` and `--params`
         options are used instead. See the 'deploy' command for valid inputs
-        for these options.
+        for these inputs.
       DESC
       c.option '-t', '--template PATH', String, <<~DESC
         Template path for a new deployment

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -60,7 +60,6 @@ module Cloudware
 
     def self.action(command, klass, method: :run!)
       command.action do |args, options|
-        delayed_require
         hash = options.__hash__
         hash.delete(:trace)
         begin
@@ -86,10 +85,6 @@ module Cloudware
       command.syntax = <<~SYNTAX.squish
         #{program(:name)} #{command.name} #{args_str} [options]
       SYNTAX
-    end
-
-    def self.delayed_require
-      require 'cloudware/models'
     end
 
     command 'cluster' do |c|

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -246,5 +246,25 @@ module Cloudware
       c.description = 'Turn the machine on'
       action(c, Commands::Powers::On)
     end
+
+    command 'render' do |c|
+      cli_syntax(c, 'NAME')
+      c.summary = 'Render a template for an existing or new deployment'
+      c.description = <<~DESC
+        Renders the template for the `NAME` deployment. Existing deployments
+        will always render the saved template path and replacements.
+
+        If the template does not exist, the `--template` and `--params`
+        options are used instead. See the 'deploy' command for valid inputs
+        for these options.
+      DESC
+      c.option '-t', '--template PATH', String, <<~DESC
+        Template path for a new deployment
+      DESC
+      c.option '--params STRING', String, <<~DESC
+        Values to be replaced for a new deployment
+      DESC
+      action(c, Commands::Deploy, method: :render)
+    end
   end
 end

--- a/lib/cloudware/cluster.rb
+++ b/lib/cloudware/cluster.rb
@@ -29,6 +29,7 @@ require 'cloudware/root_dir'
 module Cloudware
   class Cluster
     include FlightConfig::Loader
+    allow_missing_read
 
     delegate :provider, to: Config
 

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -34,9 +34,16 @@ module Cloudware
     extend Memoist
     include WithSpinner
 
+    # Override this method to delay requiring libraries until the command is
+    # called. Remember to `super`
+    def self.delayed_require
+      require 'cloudware/models'
+    end
+
     attr_reader :__config__
 
     def initialize(__config__ = nil)
+      self.class.delayed_require
       @__config__ = __config__ || CommandConfig.read
     end
 

--- a/lib/cloudware/command_config.rb
+++ b/lib/cloudware/command_config.rb
@@ -30,6 +30,7 @@ require 'active_support/core_ext/module/delegation'
 module Cloudware
   class CommandConfig
     include FlightConfig::Updater
+    allow_missing_read
 
     delegate_missing_to Config
 

--- a/lib/cloudware/commands/concerns/markdown_template.rb
+++ b/lib/cloudware/commands/concerns/markdown_template.rb
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
 
-require 'cloudware/models/deployments'
 require 'tty-color'
-require 'tty-markdown'
 
 module Cloudware
   module Commands
     module Concerns
       module MarkdownTemplate
+        def self.included(base)
+          base.extend(ClassMethods)
+        end
+
+        module ClassMethods
+          def delayed_require
+            super
+            require 'cloudware/models/deployments'
+            require 'tty-markdown'
+          end
+        end
+
         RenderCluster = Struct.new(:cluster_identifier) do
           delegate :machines, to: :deployments
           delegate_missing_to :cluster

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -60,7 +60,7 @@ module Cloudware
         raise new_e
       end
 
-      def render(name, template: nil, params: nil)
+      def render(name, template = nil, params: nil)
         cluster = __config__.current_cluster
         deployment = Models::Deployment.read(cluster, name)
         unless deployment.template_path

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -60,6 +60,17 @@ module Cloudware
         raise new_e
       end
 
+      def render(name, template: nil, params: nil)
+        cluster = __config__.current_cluster
+        deployment = Models::Deployment.read(cluster, name)
+        unless deployment.template_path
+          deployment.template_path = resolve_template(template)
+          deployment.replacements = ReplacementFactory.new(cluster, name)
+                                                      .build(params)
+        end
+        puts deployment.template
+      end
+
       def list_templates(verbose: false)
         list = build_template_list
         if list.templates.empty?
@@ -76,8 +87,6 @@ module Cloudware
       end
 
       private
-
-      attr_reader :name, :raw_path
 
       def resolve_template(template)
         build_template_list.human_paths[template] || ''

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -29,10 +29,9 @@ require 'cloudware/cluster'
 module Cloudware
   module Commands
     class Deploy < Command
-      def initialize(*a)
-        require 'cloudware/models/deployment'
-        require 'cloudware/replacement_factory'
+      def self.delayed_require
         super
+        require 'cloudware/replacement_factory'
       end
 
       def run!(name, raw_path, params: nil)

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -64,7 +64,8 @@ module Cloudware
         cluster = __config__.current_cluster
         deployment = Models::Deployment.read(cluster, name)
         unless deployment.template_path
-          deployment.template_path = resolve_template(template)
+          path = resolve_template(template, error_missing: true)
+          deployment.template_path = path
           deployment.replacements = ReplacementFactory.new(cluster, name)
                                                       .build(params)
         end
@@ -88,8 +89,11 @@ module Cloudware
 
       private
 
-      def resolve_template(template)
-        build_template_list.human_paths[template] || ''
+      def resolve_template(template, error_missing: false)
+        path = build_template_list.human_paths[template]
+        return path if path
+        return '' unless error_missing
+        raise InvalidInput, 'Could not resolve template path'
       end
 
       def build_template_list

--- a/lib/cloudware/commands/lists/deployment.rb
+++ b/lib/cloudware/commands/lists/deployment.rb
@@ -28,58 +28,17 @@ module Cloudware
   module Commands
     module Lists
       class Deployment < Command
-        TEMPLATE = <<~ERB
-          # Deployment: '<%= name %>'
-          <% if deployment_error -%>
-          *ERROR*: An error occured whilst deploying this template
-          <% unless verbose -%>
-          Please use `--verbose` for further details
-          <% end -%>
-
-          <% end -%>
-          *Creation Date*: <%= timestamp %>
-          *Template*: <%= template_path %>
-          *Provider Tag*: <%= tag %>
-
-          ## Results
-          <% if results.nil? || results.empty? -%>
-          No deployment results
-          <% else -%>
-          <% results.each do |key, value| -%>
-          - *<%= key %>*: <%= value %>
-          <% end -%>
-          <% end -%>
-
-          <% if replacements -%>
-          ## Replacements
-          <% replacements.each do |key, value| -%>
-          - *<%= key %>*: <%= value %>
-          <% end -%>
-
-          <% end -%>
-          <% if verbose && deployment_error -%>
-          ## Error
-          *NOTE:* This is `<%= provider %>'s` raw error message
-          Refer to their documentation for further details
-
-          ```
-          <%= deployment_error %>
-          ```
-
-          <% end -%>
-        ERB
-
         def self.delayed_require
           super
-          require 'cloudware/templater'
+          require 'cloudware/templaters/deployment_templater'
         end
 
         def run!(verbose: false)
           deployments = Models::Deployments.read(__config__.current_cluster)
           return puts 'No Deployments found' if deployments.empty?
-          deployments.each do |deployment|
-            puts Templater.new(deployment)
-                          .render_markdown(TEMPLATE, verbose: verbose)
+          deployments.each do |d|
+            puts Templaters::DeploymentTemplater.new(d, verbose: verbose)
+                                                .render_info
           end
         end
       end

--- a/lib/cloudware/commands/lists/deployment.rb
+++ b/lib/cloudware/commands/lists/deployment.rb
@@ -56,11 +56,13 @@ module Cloudware
           <% end -%>
           <% end -%>
 
+          <% if deployment.replacements -%>
           ## Replacements
           <% deployment.replacements.each do |key, value| -%>
           - *<%= key %>*: <%= value %>
           <% end -%>
 
+          <% end -%>
           <% if verbose && deployment.deployment_error -%>
           ## Error
           *NOTE:* This is `<%= provider %>'s` raw error message

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -33,6 +33,7 @@ require 'cloudware/exceptions'
 module Cloudware
   class Config
     include FlightConfig::Loader
+    allow_missing_read
 
     class << self
       def cache

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -68,6 +68,15 @@ module Cloudware
       end
     end
 
+    def append_tag
+      __data__.fetch(:append_tag) do
+        raise ConfigError, <<~ERROR.chomp
+          Missing 'append_tag' for provider names. See example config:
+          #{path}.example
+        ERROR
+      end
+    end
+
     def template_ext
       provider == 'azure' ? '.json' : '.yaml'
     end

--- a/lib/cloudware/log.rb
+++ b/lib/cloudware/log.rb
@@ -38,6 +38,10 @@ module Cloudware
         Config.log_file
       end
 
+      def warn(msg)
+        super
+      end
+
       delegate_missing_to :instance
     end
   end

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -142,13 +142,11 @@ module Cloudware
       end
 
       def run_destroy
-        begin
-          provider_client.destroy(tag)
-        rescue => e
-          self.deployment_error = e.message
-          Log.error(e.message)
-          return false
-        end
+        provider_client.destroy(tag)
+      rescue => e
+        self.deployment_error = e.message
+        Log.error(e.message)
+        return false
       end
 
       def render_errors_message(action)

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -42,6 +42,7 @@ module Cloudware
       include DeploymentCallbacks
 
       include FlightConfig::Updater
+      include FlightConfig::Deleter
 
       def initialize(cluster, name, **_h)
         self.cluster = cluster

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -88,7 +88,7 @@ module Cloudware
       def deploy
         run_callbacks(:deploy) do
           unless errors.blank?
-            raise ModelValidationError, render_errors_message('destroy')
+            raise ModelValidationError, render_errors_message('deploy')
           end
           run_deploy
         end

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -65,11 +65,6 @@ module Cloudware
         end
       end
 
-      def random_tag
-        __data__.set_if_empty(:random_tag, value: rand(1000000))
-        __data__.fetch(:random_tag)
-      end
-
       def results
         __data__.fetch(:results, default: {}).deep_symbolize_keys
       end
@@ -130,7 +125,7 @@ module Cloudware
       end
 
       def tag
-        "cloudware-#{name}-#{random_tag}"
+        "cloudware-deploy-#{name}"
       end
 
       private

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -136,6 +136,9 @@ module Cloudware
       rescue => e
         self.deployment_error = e.message
         Log.error(e.message)
+      rescue Interrupt
+        self.deployment_error = 'Received Interrupt!'
+        Log.error "Received SIGINT whilst deploying: #{name}"
       end
 
       def run_destroy

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -125,7 +125,7 @@ module Cloudware
       end
 
       def tag
-        "cloudware-deploy-#{name}"
+        "cloudware-#{name}-#{Config.append_tag}"
       end
 
       private

--- a/lib/cloudware/models/deployments.rb
+++ b/lib/cloudware/models/deployments.rb
@@ -33,11 +33,14 @@ module Cloudware
 
       def self.read(cluster)
         d = Dir.glob(Deployment.new(cluster, '*').path)
-               .map { |p| REGEX.match(p) }
-               .map do |matches|
-          Deployment.read(matches['cluster'], matches['name'])
-        end.sort
+               .map { |p| read_match(REGEX.match(p)) }
         new(d)
+      end
+
+      private_class_method
+
+      def self.read_match(match)
+        Deployment.read(match['cluster'], match['name'])
       end
 
       def results

--- a/lib/cloudware/models/deployments.rb
+++ b/lib/cloudware/models/deployments.rb
@@ -33,14 +33,19 @@ module Cloudware
 
       def self.read(cluster)
         d = Dir.glob(Deployment.new(cluster, '*').path)
-               .map { |p| read_match(REGEX.match(p)) }
+               .map { |p| read_path(p) }
+               .reject(&:nil?)
         new(d)
       end
 
       private_class_method
 
-      def self.read_match(match)
+      def self.read_path(path)
+        match = REGEX.match(path)
         Deployment.read(match['cluster'], match['name'])
+      rescue FlightConfig::ResourceBusy
+        Log.warn("ResourceBusy, skipping: #{path}")
+        return nil
       end
 
       def results

--- a/lib/cloudware/replacement_factory.rb
+++ b/lib/cloudware/replacement_factory.rb
@@ -57,7 +57,7 @@ module Cloudware
     def build(input_string)
       split_build_string(input_string)
         .reject(&:nil?)
-        .map { |x| parse(x) }
+        .reduce({}) { |memo, str| memo.merge(parse(str)) }
         .to_h
         .merge(deployment_name: deployment_name)
     end
@@ -71,8 +71,10 @@ module Cloudware
           '#{component_string}' does not form a key value pair
         ERROR
       end
-      key, value = components
-      [key.to_sym, parse_key_pair(key.to_sym, value)]
+      keys, value = components
+      keys.split(',').map do |key|
+        [key.to_sym, parse_key_pair(key.to_sym, value)]
+      end.to_h
     end
 
     def split_build_string(string)

--- a/lib/cloudware/spinner.rb
+++ b/lib/cloudware/spinner.rb
@@ -28,21 +28,14 @@ require 'tty-spinner'
 
 module Cloudware
   class Spinner
-    CHECK_SPIN = 10
-    SPIN_DELAY = 0.1
-
     def initialize(message, **k)
       @tty_spinner = TTY::Spinner.new(message, **k)
     end
 
     def run(done_message = '')
-      results = nil
-      thr = Thread.new { results = yield }
-      tty_spinner.spin
-      until thr.join(SPIN_DELAY)
-        tty_spinner.spin unless Config.debug
-      end
-      results
+      tty_spinner.spin      # Always spin once
+      tty_spinner.auto_spin unless Config.debug
+      yield if block_given?
     ensure
       tty_spinner.stop(done_message)
     end

--- a/lib/cloudware/templater.rb
+++ b/lib/cloudware/templater.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#
+# =============================================================================
+# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd
+#
+# This file is part of Alces Cloudware.
+#
+# Alces Cloudware is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Alces Cloudware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Alces Cloudware.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Cloudware, please visit:
+# https://github.com/alces-software/cloudware
+# ==============================================================================
+#
+
+require 'tty-markdown'
+
+module Cloudware
+  class Templater < SimpleDelegator
+    def render(template, **kwargs)
+      bind = kwargs.each_with_object(binding) do |(key, value), scope|
+        scope.local_variable_set(key, value)
+      end
+      ERB.new(template, nil, '-').result(bind)
+    end
+
+    def render_markdown(template, **kwargs)
+      TTY::Markdown.parse(render(template, **kwargs))
+    end
+  end
+end

--- a/lib/cloudware/templaters/deployment_templater.rb
+++ b/lib/cloudware/templaters/deployment_templater.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#
+# =============================================================================
+# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd
+#
+# This file is part of Alces Cloudware.
+#
+# Alces Cloudware is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Alces Cloudware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Alces Cloudware.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Cloudware, please visit:
+# https://github.com/alces-software/cloudware
+# ==============================================================================
+#
+
+require 'cloudware/templater'
+
+module Cloudware
+  module Templaters
+    class DeploymentTemplater < Templater
+      attr_reader :verbose
+
+      def initialize(obj, verbose: false)
+        super(obj)
+        @verbose = verbose
+      end
+
+      def render_info
+        render_markdown <<~ERB
+          # Deployment: '<%= name %>'
+          <% if deployment_error -%>
+          *ERROR*: An error occured whilst deploying this template
+          <% unless verbose -%>
+          Please use `--verbose` for further details
+          <% end -%>
+
+          <% end -%>
+          *Creation Date*: <%= timestamp %>
+          *Template*: <%= template_path %>
+          *Provider Tag*: <%= tag %>
+
+          ## Results
+          <% if results.nil? || results.empty? -%>
+          No deployment results
+          <% else -%>
+          <% results.each do |key, value| -%>
+          - *<%= key %>*: <%= value %>
+          <% end -%>
+          <% end -%>
+
+          <% if replacements -%>
+          ## Replacements
+          <% replacements.each do |key, value| -%>
+          - *<%= key %>*: <%= value %>
+          <% end -%>
+
+          <% end -%>
+          <% if verbose && deployment_error -%>
+          ## Error
+          *NOTE:* This is `<%= provider %>'s` raw error message
+          Refer to their documentation for further details
+
+          ```
+          <%= deployment_error %>
+          ```
+
+          <% end -%>
+        ERB
+      end
+    end
+  end
+end

--- a/spec/cloudware/replacement_factory_spec.rb
+++ b/spec/cloudware/replacement_factory_spec.rb
@@ -122,6 +122,14 @@ RSpec.describe Cloudware::ReplacementFactory do
       it_behaves_like 'a literal key value replacement'
     end
 
+    context 'with a multi {key1,key2}=value string' do
+      let(:value) { 'my-value' }
+      let(:input_string) { "other_key,#{key}=#{value}" }
+
+      it_behaves_like 'a default replacement'
+      it_behaves_like 'a literal key value replacement'
+    end
+
     context 'when the value contains a correctly quoted space' do
       let(:value) { 'some string with spaces' }
       let(:input_string) { "#{key}='#{value}'" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,8 @@ RSpec.configure do |config|
     FileUtils.mkdir_p(File.dirname(dst))
     FakeFS::FileSystem.clone(src, dst)
 
+    FileUtils.mkdir_p(File.dirname(Cloudware::Config.log_file))
+
     # Stub the `flock` method in the tests as FakeFS doesn't implement it
     allow_any_instance_of(File).to receive(:flock)
   end


### PR DESCRIPTION
The syntax for the replacement parameters have been updated to allow multiple keys to reference the same deployment: `key1,key2=*deployment`

There is now a `render` command which will generate templates for existing and new deployments.

Finally there has been some code profiling added to work out the slow boot time. Some of the requires have been delayed, fixes #74