### PR TITLE
Make the provider tags unique to the cluster

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,10 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: bf69306f64d76dd36c2fd25bb88e083b66dfc789
+  revision: 02e2836a252b3402f547da43a836c94bb2942796
   specs:
     flight_config (0.1.0)
       fakefs
-      ice_nine
       tty-config
 
 GEM
@@ -64,7 +63,6 @@ GEM
       domain_name (~> 0.5)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
-    ice_nine (0.11.2)
     ipaddr (1.2.0)
     jmespath (1.3.1)
     kramdown (1.16.2)
@@ -195,4 +193,4 @@ DEPENDENCIES
   tty-table
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: 02e2836a252b3402f547da43a836c94bb2942796
+  revision: 2b8d77c5010cc96aa4c8b0058a0309cb1cbd3adf
   specs:
     flight_config (0.1.0)
       fakefs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,10 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: 6710c22291f1733ae029a2898993b3ab77a9787b
+  revision: 72c041c6e39b681c3d9b3be07893e58ff12dc5f8
   specs:
     flight_config (0.1.0)
+      ice_nine
       tty-config
 
 GEM
@@ -62,6 +63,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     ipaddr (1.2.0)
     jmespath (1.3.1)
     kramdown (1.16.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,10 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: 72c041c6e39b681c3d9b3be07893e58ff12dc5f8
+  revision: bf69306f64d76dd36c2fd25bb88e083b66dfc789
   specs:
     flight_config (0.1.0)
+      fakefs
       ice_nine
       tty-config
 
@@ -51,7 +52,7 @@ GEM
     equatable (0.5.0)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    fakefs (0.18.0)
+    fakefs (0.19.2)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)

--- a/etc/config.yaml.example
+++ b/etc/config.yaml.example
@@ -8,9 +8,11 @@
 # for details.
 # =============================================================================
 
-# The deployments name on the provider will be appended with this tag. This
-# should be unique for this install of cloudware
-append_tag: # REQUIRED
+# Prefix Tag:
+# The names given to remote resources will be prefixed with this tag. It should
+# be used to distinguish these cloud resources from anything else deployed on
+# your account.
+prefix_tag: # [STRONGLY RECOMMENDED] : Should be unique
 
 # Provider credentials
 azure:                        # Requirement for cloud-azure

--- a/etc/config.yaml.travis
+++ b/etc/config.yaml.travis
@@ -11,4 +11,4 @@ aws:                            # Requirement for cloud-aws
   secret_access_key:  # [VALUE] : Requirement for cloud-aws
 
 log_file: /tmp/travis.log
-append_tag: travis
+prefix_tag: travis-cloud

--- a/lib/cloudware/command_config.rb
+++ b/lib/cloudware/command_config.rb
@@ -39,7 +39,11 @@ module Cloudware
     end
 
     def current_cluster
-      __data__.fetch(:current_cluster) { 'default' }
+      __data__.fetch(:current_cluster) do
+        path = Models::Cluster.new('default').path
+        return 'default' if File.exists?(path)
+        Models::Cluster.create('default').identifier
+      end
     end
 
     def current_cluster=(cluster)

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -42,12 +42,11 @@ module Cloudware
         <% end -%>
       ERB
 
-      def init(cluster, import: nil)
-        error_if_exists(cluster, action: 'create')
-        update_cluster(cluster)
-        FileUtils.mkdir_p File.dirname(Models::Cluster.read(cluster).path)
+      def init(identifier, import: nil)
+        new_cluster = Models::Cluster.create(identifier)
+        update_cluster(new_cluster.identifier)
         Import.new(__config__).run!(import) if import
-        puts "Created cluster: #{cluster}"
+        puts "Created cluster: #{new_cluster.identifier}"
       end
 
       def list

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -63,7 +63,7 @@ module Cloudware
       private
 
       def update_cluster(new_cluster)
-        @__config__ = CommandConfig.update do |conf|
+        @__config__ = CommandConfig.create_or_update do |conf|
           conf.current_cluster = new_cluster
         end
       end

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -24,7 +24,7 @@
 # ==============================================================================
 #
 
-require 'cloudware/cluster'
+require 'cloudware/models/cluster'
 require 'cloudware/commands/import'
 require 'pathname'
 
@@ -45,7 +45,7 @@ module Cloudware
       def init(cluster, import: nil)
         error_if_exists(cluster, action: 'create')
         update_cluster(cluster)
-        FileUtils.mkdir_p File.dirname(Cluster.read(cluster).path)
+        FileUtils.mkdir_p File.dirname(Models::Cluster.read(cluster).path)
         Import.new(__config__).run!(import) if import
         puts "Created cluster: #{cluster}"
       end
@@ -69,7 +69,7 @@ module Cloudware
       end
 
       def read_clusters
-        Dir.glob(Cluster.new('*').path)
+        Dir.glob(Models::Cluster.new('*').path)
            .map { |p| File.basename(p) }
            .sort
       end

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -69,9 +69,7 @@ module Cloudware
       end
 
       def read_clusters
-        Dir.glob(Models::Cluster.new('*').path)
-           .map { |p| File.basename(p) }
-           .sort
+        Models::Cluster.glob_read('*').map { |c| c.identifier }
       end
 
       def error_if_exists(cluster, action:)

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -24,8 +24,6 @@
 # ==============================================================================
 #
 
-require 'cloudware/cluster'
-
 module Cloudware
   module Commands
     class Deploy < Command

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -72,7 +72,6 @@ module Cloudware
     def prefix_tag
       __data__.fetch(:prefix_tag, default: 'cloudware-shared')
     end
-    alias :append_tag :prefix_tag
 
     def template_ext
       provider == 'azure' ? '.json' : '.yaml'

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -69,14 +69,10 @@ module Cloudware
       end
     end
 
-    def append_tag
-      __data__.fetch(:append_tag) do
-        raise ConfigError, <<~ERROR.chomp
-          Missing 'append_tag' for provider names. See example config:
-          #{path}.example
-        ERROR
-      end
+    def prefix_tag
+      __data__.fetch(:prefix_tag, default: 'cloudware-shared')
     end
+    alias :append_tag :prefix_tag
 
     def template_ext
       provider == 'azure' ? '.json' : '.yaml'

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -41,11 +41,13 @@ module Cloudware
       end
 
       delegate_missing_to :cache
-    end
 
-    def initialize
-      __data__.env_prefix = 'cloudware'
-      ['provider', 'debug', 'app_name'].each { |x| __data__.set_from_env(x) }
+      def new__data__
+        super.tap do |__data__|
+          __data__.env_prefix = 'cloudware'
+          ['provider', 'debug', 'app_name'].each { |x| __data__.set_from_env(x) }
+        end
+      end
     end
 
     def path

--- a/lib/cloudware/models/application.rb
+++ b/lib/cloudware/models/application.rb
@@ -36,13 +36,6 @@ module Cloudware
 
       include ActiveModel::Model
       extend Memoist
-
-      def initialize(*_a, **parameters)
-        @errors = ActiveModel::Errors.new(self)
-        parameters.each do |key, value|
-          public_send("#{key}=", value)
-        end
-      end
     end
   end
 end

--- a/lib/cloudware/models/cluster.rb
+++ b/lib/cloudware/models/cluster.rb
@@ -30,6 +30,7 @@ module Cloudware
   module Models
     class Cluster
       include FlightConfig::Loader
+      include FlightConfig::Globber
       allow_missing_read
 
       delegate :provider, to: Config

--- a/lib/cloudware/models/cluster.rb
+++ b/lib/cloudware/models/cluster.rb
@@ -25,12 +25,20 @@
 #
 
 require 'cloudware/root_dir'
+require 'securerandom'
 
 module Cloudware
   module Models
     class Cluster
       include FlightConfig::Updater
       include FlightConfig::Globber
+
+      def self.create(cluster)
+        super(cluster) do |config|
+          # Ensure the tag has been assigned
+          config.tag
+        end
+      end
 
       delegate :provider, to: Config
 
@@ -46,6 +54,12 @@ module Cloudware
 
       def region
         __data__.fetch(:region) { Config.default_region }
+      end
+
+      def tag
+        __data__.fetch(:tag) do
+          SecureRandom.hex(5).tap { |id| __data__.set(:id, value: id) }
+        end
       end
 
       def deployments

--- a/lib/cloudware/models/cluster.rb
+++ b/lib/cloudware/models/cluster.rb
@@ -48,6 +48,10 @@ module Cloudware
         @identifier = identifier
       end
 
+      def __data__initialize(data)
+        data.set(:tag, value: SecureRandom.hex(5))
+      end
+
       def path
         RootDir.content_cluster(identifier, 'etc/config.yaml')
       end
@@ -57,9 +61,7 @@ module Cloudware
       end
 
       def tag
-        __data__.fetch(:tag) do
-          SecureRandom.hex(5).tap { |id| __data__.set(:tag, value: id) }
-        end
+        __data__.fetch(:tag)
       end
 
       def deployments

--- a/lib/cloudware/models/cluster.rb
+++ b/lib/cloudware/models/cluster.rb
@@ -31,7 +31,6 @@ module Cloudware
     class Cluster
       include FlightConfig::Updater
       include FlightConfig::Globber
-      allow_missing_read
 
       delegate :provider, to: Config
 

--- a/lib/cloudware/models/cluster.rb
+++ b/lib/cloudware/models/cluster.rb
@@ -27,28 +27,30 @@
 require 'cloudware/root_dir'
 
 module Cloudware
-  class Cluster
-    include FlightConfig::Loader
-    allow_missing_read
+  module Models
+    class Cluster
+      include FlightConfig::Loader
+      allow_missing_read
 
-    delegate :provider, to: Config
+      delegate :provider, to: Config
 
-    attr_reader :identifier
+      attr_reader :identifier
 
-    def initialize(identifier)
-      @identifier = identifier
-    end
+      def initialize(identifier)
+        @identifier = identifier
+      end
 
-    def path
-      RootDir.content_cluster(identifier, 'etc/config.yaml')
-    end
+      def path
+        RootDir.content_cluster(identifier, 'etc/config.yaml')
+      end
 
-    def region
-      __data__.fetch(:region) { Config.default_region }
-    end
+      def region
+        __data__.fetch(:region) { Config.default_region }
+      end
 
-    def deployments
-      Models::Deployments.read(identifier)
+      def deployments
+        Models::Deployments.read(identifier)
+      end
     end
   end
 end

--- a/lib/cloudware/models/cluster.rb
+++ b/lib/cloudware/models/cluster.rb
@@ -58,7 +58,7 @@ module Cloudware
 
       def tag
         __data__.fetch(:tag) do
-          SecureRandom.hex(5).tap { |id| __data__.set(:id, value: id) }
+          SecureRandom.hex(5).tap { |id| __data__.set(:tag, value: id) }
         end
       end
 

--- a/lib/cloudware/models/cluster.rb
+++ b/lib/cloudware/models/cluster.rb
@@ -29,7 +29,7 @@ require 'cloudware/root_dir'
 module Cloudware
   module Models
     class Cluster
-      include FlightConfig::Loader
+      include FlightConfig::Updater
       include FlightConfig::Globber
       allow_missing_read
 

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -114,7 +114,7 @@ module Cloudware
       def region
         # Protect the read from a `nil` cluster. There is a separate validation
         # for nil clusters
-        Cluster.read(cluster.to_s).region
+        Models::Cluster.read(cluster.to_s).region
       end
 
       def <=>(other)

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -43,6 +43,7 @@ module Cloudware
 
       include FlightConfig::Updater
       include FlightConfig::Deleter
+      include FlightConfig::Globber
 
       def initialize(cluster, name, **_h)
         self.cluster = cluster

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -48,7 +48,6 @@ module Cloudware
       def initialize(cluster, name, **_h)
         self.cluster = cluster
         self.name = name
-        super
       end
 
       SAVE_ATTR = [

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -67,6 +67,12 @@ module Cloudware
         end
       end
 
+      def cluster_config
+        # Protect the read from a `nil` cluster. There is a separate validation
+        # for nil clusters
+        @cluster_config ||= Models::Cluster.read(cluster.to_s)
+      end
+
       def results
         __data__.fetch(:results, default: {}).deep_symbolize_keys
       end
@@ -112,9 +118,7 @@ module Cloudware
       end
 
       def region
-        # Protect the read from a `nil` cluster. There is a separate validation
-        # for nil clusters
-        Models::Cluster.read(cluster.to_s).region
+        cluster_config.region
       end
 
       def <=>(other)
@@ -127,7 +131,7 @@ module Cloudware
       end
 
       def tag
-        "cloudware-#{name}-#{Config.append_tag}"
+        "#{Config.prefix_tag}-#{name}-#{cluster_config.tag}"
       end
 
       private

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -150,6 +150,7 @@ module Cloudware
 
       def run_destroy
         provider_client.destroy(tag)
+        true
       rescue => e
         self.deployment_error = e.message
         Log.error(e.message)

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -45,14 +45,16 @@ module Cloudware
       include FlightConfig::Deleter
       include FlightConfig::Globber
 
+      attr_reader :cluster, :name
+
       def initialize(cluster, name, **_h)
-        self.cluster = cluster
-        self.name = name
+        @cluster = cluster
+        @name = name
       end
 
       SAVE_ATTR = [
-        :template_path, :name, :results, :replacements,
-        :deployment_error, :cluster, :epoch_time
+        :template_path, :results, :replacements,
+        :deployment_error, :epoch_time
       ].freeze
 
       SAVE_ATTR.each do |method|

--- a/lib/cloudware/models/deployments.rb
+++ b/lib/cloudware/models/deployments.rb
@@ -29,23 +29,8 @@ require 'cloudware/models/deployment'
 module Cloudware
   module Models
     class Deployments < DelegateClass(Array)
-      REGEX = /#{Deployment.new('(?<cluster>.*)', '(?<name>.*)').path}/
-
       def self.read(cluster)
-        d = Dir.glob(Deployment.new(cluster, '*').path)
-               .map { |p| read_path(p) }
-               .reject(&:nil?)
-        new(d)
-      end
-
-      private_class_method
-
-      def self.read_path(path)
-        match = REGEX.match(path)
-        Deployment.read(match['cluster'], match['name'])
-      rescue FlightConfig::ResourceBusy
-        Log.warn("ResourceBusy, skipping: #{path}")
-        return nil
+        new(Deployment.glob_read(cluster, '*'))
       end
 
       def results

--- a/spec/cloudware/models/deployment_spec.rb
+++ b/spec/cloudware/models/deployment_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe Cloudware::Models::Deployment do
   end
 
   subject do
-    build(:deployment, replacements: replacements)
+    build(:deployment, replacements: replacements).tap do |deployment|
+      Cloudware::Models::Cluster.create_or_update(deployment.cluster)
+    end
   end
 
   let(:replacements) { nil }

--- a/spec/cloudware/models/deployment_spec.rb
+++ b/spec/cloudware/models/deployment_spec.rb
@@ -101,7 +101,9 @@ RSpec.describe Cloudware::Models::Deployment do
         end
 
         context 'without a cluster' do
-          before { subject.cluster = nil }
+          before do
+            allow(subject).to receive(:cluster).and_return(nil)
+          end
 
           include_examples 'deploy raises ModelValidationError'
         end

--- a/spec/cloudware/models/machine_spec.rb
+++ b/spec/cloudware/models/machine_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Cloudware::Models::Machine do
     let(:deployment) do
       build(:deployment, results: deployment_results).tap do |d|
         FlightConfig::Core.write(d)
+        Cloudware::Models::Cluster.create(d.cluster)
       end
     end
 

--- a/spec/cloudware/models/machine_spec.rb
+++ b/spec/cloudware/models/machine_spec.rb
@@ -33,7 +33,10 @@ RSpec.describe Cloudware::Models::Machine do
 
   context 'with a blank deployment' do
     let!(:deployment) do
-      build(:deployment).tap { |d| FlightConfig::Core.write(d) }
+      build(:deployment).tap do |d|
+        FlightConfig::Core.write(d)
+        Cloudware::Models::Cluster.create(d.cluster)
+      end
     end
 
     describe '#provider_id' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -34,8 +34,11 @@ FactoryBot.define do
       new(
         attributes.delete(:cluster),
         attributes.delete(:name),
-        **attributes
-      )
+      ).tap do |deployment|
+        attributes.each do |key, value|
+          deployment.send("#{key}=", value)
+        end
+      end
     end
 
     name 'test-deployment'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -31,11 +31,12 @@ FactoryBot.define do
 
   factory :deployment, class: models::Deployment do
     initialize_with do
+      attr = attributes.dup
       new(
-        attributes.delete(:cluster),
-        attributes.delete(:name),
+        attr.delete(:cluster),
+        attr.delete(:name),
       ).tap do |deployment|
-        attributes.each do |key, value|
+        attr.each do |key, value|
           deployment.send("#{key}=", value)
         end
       end


### PR DESCRIPTION
This PR updates the provider tag to be in line with and fixes #197.

It required properly defining `create` methods for the now `Models::Cluster` object. The end component is a random tag that is generated when it is first created. This uses the updated `FlightConfig` syntax.

File globbing has also been generalised. This allows for the `Clusters` and `Deployments` arrays to be generated in a similar fashion