### PR TITLE
Introduce an offline mode for the deployments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/flight_config
-  revision: 2b8d77c5010cc96aa4c8b0058a0309cb1cbd3adf
+  revision: 0a0137d42fd5d6122e56b827c400bafa93b82520
   specs:
     flight_config (0.1.0)
       fakefs

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -188,6 +188,7 @@ module Cloudware
     command 'list deployments' do |c|
       cli_syntax(c)
       c.description = 'List all the previous deployed templates'
+      c.option '-a', '--all', 'Include offline deployments'
       c.option '-v', '--verbose', 'Show full error messages'
       action(c, Commands::Lists::Deployment)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -133,9 +133,23 @@ module Cloudware
 
     command 'destroy' do |c|
       cli_syntax(c, 'NAME')
-      c.summary = 'Destroy the remote infrastructure created by a deployment'
-      c.option '--force', 'Force delete the deployment from the context'
+      c.summary = 'Stop a running deployment'
       action(c, Commands::Destroy)
+    end
+
+    command 'delete' do |c|
+      cli_syntax(c, 'NAME')
+      c.summary = 'Remove the deployments configuration file'
+      c.description = <<~DESC
+        Deletes the confiuration file for the deployment NAME. This action
+        will error if the resources are currently running. The resources can
+        be stop using the 'destroy' command.
+
+        The configuration of a currently running deployment can be deleted
+        using the '--force' flag. This will not destroy the remote resources
+      DESC
+      c.option '--force', 'Delete the deployment regardless if running'
+      action(c, Commands::Destroy, method: :delete)
     end
 
     command 'import' do |c|

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -112,6 +112,12 @@ module Cloudware
       action(c, Commands::ClusterCommand, method: :switch)
     end
 
+    command 'cluster delete' do |c|
+      cli_syntax(c, 'CLUSTER')
+      c.summary = 'Destroys the deployments and deletes the cluster'
+      action(c, Commands::ClusterCommand, method: :delete)
+    end
+
     command 'deploy' do |c|
       cli_syntax(c, 'NAME [TEMPLATE]')
       c.summary = 'Deploy new resource(s) define by a template'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -133,11 +133,7 @@ module Cloudware
 
     command 'destroy' do |c|
       cli_syntax(c, 'NAME')
-      c.summary = 'Destroy a deployment and related resouces'
-      c.description = <<~DESC
-        Removes the deployment NAME and instructs the cloud provider to destroy
-        the related resources.
-      DESC
+      c.summary = 'Destroy the remote infrastructure created by a deployment'
       c.option '--force', 'Force delete the deployment from the context'
       action(c, Commands::Destroy)
     end

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -122,16 +122,22 @@ module Cloudware
       cli_syntax(c, 'NAME [TEMPLATE]')
       c.summary = 'Deploy new resource(s) define by a template'
       c.description = <<-DESC.strip_heredoc
-        Deploy new resource(s) from the specified TEMPLATE. The TEMPLATE can
-        either be a cluster template or an absolute path. The TEMPLATE should
-        not be included when redeploying existing resources.
+        When called with a single argument, it will deploy a currently existing
+        deployment: NAME. This will result in an error if the deployment does
+        not exist or is currently in a deployed state.
 
-        The deployment will be given the NAME label and logged locally. The name
-        used by the provider will be based off this with minor variations.
+        Calling it with a second argument will try and create a nem deployment
+        called NAME with the specified TEMPLATE. The TEMPLATE references the
+        internal template which have been imported. Alternatively it can be
+        an absolute path to a template file.
+
+        In either case, the template is read and sent to the provider. The
+        template is read each time it is re-deployed. Be careful not to delete
+        or modify it.
 
         The templates also support basic rendering of parameters from the
         command line. This is intended to provide minor tweaks to the templates
-        (e.g. IPs or names). Major difference should use separate templates.
+        (e.g. IPs or names).
       DESC
       c.option '-p', '--params \'<REPLACE_KEY=*IDENTIFIER[.OUTPUT_KEY] >...\'',
                String, 'A space separated list of keys to be replaced'

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -113,11 +113,12 @@ module Cloudware
     end
 
     command 'deploy' do |c|
-      cli_syntax(c, 'NAME TEMPLATE')
+      cli_syntax(c, 'NAME [TEMPLATE]')
       c.summary = 'Deploy new resource(s) define by a template'
       c.description = <<-DESC.strip_heredoc
         Deploy new resource(s) from the specified TEMPLATE. The TEMPLATE can
-        either be a cluster template or an absolute path.
+        either be a cluster template or an absolute path. The TEMPLATE should
+        not be included when redeploying existing resources.
 
         The deployment will be given the NAME label and logged locally. The name
         used by the provider will be based off this with minor variations.

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -43,7 +43,7 @@ module Cloudware
       ERB
 
       def init(identifier, import: nil)
-        new_cluster = Models::Cluster.create(identifier)
+        new_cluster = Models::Cluster.create!(identifier)
         update_cluster(new_cluster.identifier)
         Import.new(__config__).run!(import) if import
         puts "Created cluster: #{new_cluster.identifier}"

--- a/lib/cloudware/commands/cluster_command.rb
+++ b/lib/cloudware/commands/cluster_command.rb
@@ -42,6 +42,11 @@ module Cloudware
         <% end -%>
       ERB
 
+      def initialize(*_a)
+        require 'parallel'
+        super
+      end
+
       def init(identifier, import: nil)
         new_cluster = Models::Cluster.create!(identifier)
         update_cluster(new_cluster.identifier)
@@ -57,6 +62,21 @@ module Cloudware
         error_if_missing(cluster, action: 'switch')
         update_cluster(cluster)
         list
+      end
+
+      def delete(cluster)
+        error_if_current_cluster(cluster)
+        deps = Models::Deployments.read(cluster)
+        with_spinner 'Deleting cluster (this may take some time)...'
+          Parallel.each(deps, in_threads: 5) do |dep|
+            Models::Deployment.destroy!(cluster, dep.name)
+            Models::Deployment.delete!(cluster, dep.name)
+          end
+        if Models::Deployments.read(cluster).empty?
+          FileUtils.rm_rf RootDir.content_cluster(cluster)
+        else
+          raise CloudwareError, 'Failed to delete the cluster'
+        end
       end
 
       private
@@ -82,6 +102,13 @@ module Cloudware
         return if read_clusters.include?(cluster)
         raise InvalidInput, <<~ERROR.chomp
           Failed to #{action} cluster. '#{cluster}' doesn't exist
+        ERROR
+      end
+
+      def error_if_current_cluster(cluster)
+        return unless cluster == __config__.current_cluster
+        raise InvalidInput, <<~ERROR.chomp
+          Can not delete the current cluster
         ERROR
       end
     end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -36,7 +36,7 @@ module Cloudware
         cur_dep = if raw_path
           create_deployment(name, raw_path, params: params)
         else
-          Models::Deployment.read(__config__.current_cluster, name)
+          Models::Deployment.read!(__config__.current_cluster, name)
         end
         raise_if_deployed(cur_dep)
         puts "Deploying: #{cur_dep.path}"

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -32,9 +32,13 @@ module Cloudware
         require 'cloudware/replacement_factory'
       end
 
-      def run!(name, raw_path, params: nil)
-        created_dep = create_deployment(name, raw_path, params: params)
-        puts "Deploying: #{created_dep.path}"
+      def run!(name, raw_path = nil, params: nil)
+        cur_dep = if raw_path
+          create_deployment(name, raw_path, params: params)
+        else
+          Models::Deployment.read(__config__.current_cluster, name)
+        end
+        puts "Deploying: #{cur_dep.path}"
         with_spinner('Deploying resources...', done: 'Done') do
           dep = Models::Deployment.deploy!(__config__.current_cluster, name)
           return unless dep.deployment_error

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -38,6 +38,7 @@ module Cloudware
         else
           Models::Deployment.read(__config__.current_cluster, name)
         end
+        raise_if_deployed(cur_dep)
         puts "Deploying: #{cur_dep.path}"
         with_spinner('Deploying resources...', done: 'Done') do
           dep = Models::Deployment.deploy!(__config__.current_cluster, name)
@@ -86,6 +87,12 @@ module Cloudware
           template: resolve_template(raw_path),
           replacements: replacements
         )
+      end
+
+      def raise_if_deployed(dep)
+        return unless dep.deployed
+        raise InvalidInput, "'#{dep.name}' is already running"
+        ERROR
       end
 
       def resolve_template(template, error_missing: false)

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -59,7 +59,7 @@ module Cloudware
 
       def render(name, template = nil, params: nil)
         cluster = __config__.current_cluster
-        deployment = Models::Deployment.read(cluster, name)
+        deployment = Models::Deployment.read_or_new(cluster, name)
         unless deployment.template_path
           path = resolve_template(template, error_missing: true)
           deployment.template_path = path

--- a/lib/cloudware/commands/destroy.rb
+++ b/lib/cloudware/commands/destroy.rb
@@ -37,7 +37,7 @@ module Cloudware
       def run
         @name = argv[0]
         with_spinner('Destroying resources...', done: 'Done') do
-          Models::Deployment.delete!(__config__.current_cluster, name)
+          Models::Deployment.destroy!(__config__.current_cluster, name)
         end
       end
     end

--- a/lib/cloudware/commands/destroy.rb
+++ b/lib/cloudware/commands/destroy.rb
@@ -40,6 +40,14 @@ module Cloudware
           Models::Deployment.destroy!(__config__.current_cluster, name)
         end
       end
+
+      def delete(name, force: false)
+        if force
+          Models::Deployment.delete(__config__.current_cluster, name)
+        else
+          Models::Deployment.delete!(__config__.current_cluster, name)
+        end
+      end
     end
   end
 end

--- a/lib/cloudware/commands/destroy.rb
+++ b/lib/cloudware/commands/destroy.rb
@@ -36,16 +36,9 @@ module Cloudware
 
       def run
         @name = argv[0]
-        cluster = __config__.current_cluster
-        deployment = Models::Deployment.delete(cluster, name) do |d|
-          with_spinner('Destroying resources...', done: 'Done') do
-            d.destroy(force: options.force)
-          end
+        with_spinner('Destroying resources...', done: 'Done') do
+          Models::Deployment.delete!(__config__.current_cluster, name)
         end
-        return unless deployment.nil?
-        raise InvalidInput, <<~ERROR.chomp
-            Could not find deployment '#{name}'
-        ERROR
       end
     end
   end

--- a/lib/cloudware/commands/lists/deployment.rb
+++ b/lib/cloudware/commands/lists/deployment.rb
@@ -33,8 +33,9 @@ module Cloudware
           require 'cloudware/templaters/deployment_templater'
         end
 
-        def run!(verbose: false)
+        def run!(verbose: false, all: false)
           deployments = Models::Deployments.read(__config__.current_cluster)
+          deployments = deployments.select(&:deployed) unless all
           return puts 'No Deployments found' if deployments.empty?
           deployments.each do |d|
             puts Templaters::DeploymentTemplater.new(d, verbose: verbose)

--- a/lib/cloudware/models/cluster.rb
+++ b/lib/cloudware/models/cluster.rb
@@ -33,8 +33,8 @@ module Cloudware
       include FlightConfig::Updater
       include FlightConfig::Globber
 
-      def self.create(cluster)
-        super(cluster) do |config|
+      def self.create!(cluster)
+        create(cluster) do |config|
           # Ensure the tag has been assigned
           config.tag
         end

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -37,7 +37,8 @@ require 'erb'
 
 module Cloudware
   module Models
-    class Deployment < Application
+    class Deployment
+      include ActiveModel::Validations
       include Concerns::ProviderClient
       include DeploymentCallbacks
 
@@ -95,21 +96,19 @@ module Cloudware
       end
 
       def deploy
-        run_callbacks(:deploy) do
-          unless errors.blank?
-            raise ModelValidationError, render_errors_message('deploy')
-          end
-          run_deploy
+        validate
+        unless errors.blank?
+          raise ModelValidationError, render_errors_message('deploy')
         end
+        run_deploy
       end
 
       def destroy(force: false)
-        run_callbacks(:destroy) do
-          unless errors.blank?
-            raise ModelValidationError, render_errors_message('destroy')
-          end
-          run_destroy
+        validate
+        unless errors.blank?
+          raise ModelValidationError, render_errors_message('destroy')
         end
+        run_destroy
       end
 
       def to_h

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -48,6 +48,13 @@ module Cloudware
 
       attr_reader :cluster, :name
 
+      # Override create to always write the file into a basic state
+      def self.create!(*a)
+        create(*a) do |dep|
+          dep.validate_or_error('create')
+        end
+      end
+
       def initialize(cluster, name, **_h)
         @cluster = cluster
         @name = name
@@ -96,18 +103,12 @@ module Cloudware
       end
 
       def deploy
-        validate
-        unless errors.blank?
-          raise ModelValidationError, render_errors_message('deploy')
-        end
+        validate_or_error('deploy')
         run_deploy
       end
 
       def destroy(force: false)
-        validate
-        unless errors.blank?
-          raise ModelValidationError, render_errors_message('destroy')
-        end
+        validate_or_error('destroy')
         run_destroy
       end
 
@@ -132,6 +133,13 @@ module Cloudware
 
       def tag
         "#{Config.prefix_tag}-#{name}-#{cluster_config.tag}"
+      end
+
+      def validate_or_error(action)
+        validate
+        unless errors.blank?
+          raise ModelValidationError, render_errors_message(action)
+        end
       end
 
       private

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -69,6 +69,17 @@ module Cloudware
         reraise_missing_file { update(*a, &:destroy) }
       end
 
+      def self.delete!(*a)
+        reraise_missing_file do
+          delete(*a) do |dep|
+            next true unless dep.deployed
+            raise DeploymentError, <<~ERROR.chomp
+              Can not delete a currently running deployment
+            ERROR
+          end
+        end
+      end
+
       private_class_method
 
       def self.reraise_missing_file

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -53,7 +53,7 @@ module Cloudware
           dep.validate_or_error('create')
         end
       rescue FlightConfig::CreateError => e
-        raise e.exception "Cowardly refusing to recreate '#{name}'"
+        raise e.exception "Cowardly refusing to recreate '#{dep.name}'"
       end
 
       def self.deploy!(*a)

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -46,6 +46,10 @@ module Cloudware
       include FlightConfig::Deleter
       include FlightConfig::Globber
 
+      def self.read!(*a)
+        reraise_missing_file { read(*a) }
+      end
+
       def self.create!(*a, template:, replacements:)
         create(*a) do |dep|
           dep.template_path = template
@@ -53,7 +57,7 @@ module Cloudware
           dep.validate_or_error('create')
         end
       rescue FlightConfig::CreateError => e
-        raise e.exception "Cowardly refusing to recreate '#{dep.name}'"
+        raise e.exception "Cowardly refusing to recreate the deployment"
       end
 
       def self.deploy!(*a)

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -161,6 +161,10 @@ module Cloudware
         self.deployment_error = e.message
         Log.error(e.message)
         return false
+      rescue Interrupt
+        self.deployment_error = 'Received Interrupt!'
+        Log.error(e.message)
+        return false
       end
 
       def to_h

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -65,8 +65,8 @@ module Cloudware
         end
       end
 
-      def self.delete!(*a)
-        reraise_missing_file { delete(*a, &:destroy) }
+      def self.destroy!(*a)
+        reraise_missing_file { update(*a, &:destroy) }
       end
 
       private_class_method
@@ -85,7 +85,7 @@ module Cloudware
       end
 
       SAVE_ATTR = [
-        :template_path, :results, :replacements,
+        :template_path, :results, :replacements, :deployed,
         :deployment_error, :epoch_time
       ].freeze
 
@@ -127,6 +127,7 @@ module Cloudware
       end
 
       def deploy
+        self.deployed = true
         self.epoch_time = Time.now.to_i
         self.results = provider_client.deploy(tag, template)
       rescue => e
@@ -139,6 +140,7 @@ module Cloudware
 
       def destroy(force: false)
         provider_client.destroy(tag)
+        self.deployed = false
         true
       rescue => e
         self.deployment_error = e.message

--- a/lib/cloudware/models/deployment_callbacks.rb
+++ b/lib/cloudware/models/deployment_callbacks.rb
@@ -28,13 +28,10 @@ module Cloudware
   module Models
     module DeploymentCallbacks
       def self.included(base)
-        base.class_eval do
-          define_model_callbacks :deploy
-          define_model_callbacks :destroy
-
-          before_deploy :validate_template_exists
-          before_deploy :validate_replacement_tags
-          before_deploy :validate_cluster
+        base.class_exec do
+          validate :validate_template_exists
+          validate :validate_replacement_tags
+          validate :validate_cluster
         end
       end
 

--- a/lib/cloudware/templaters/deployment_templater.rb
+++ b/lib/cloudware/templaters/deployment_templater.rb
@@ -47,6 +47,7 @@ module Cloudware
 
           <% end -%>
           *Creation Date*: <%= timestamp %>
+          *Status*: <%= deployed ? 'Running' : 'Offline' %>
           *Template*: <%= template_path %>
           *Provider Tag*: <%= tag %>
 

--- a/spec/cloudware/models/deployment_spec.rb
+++ b/spec/cloudware/models/deployment_spec.rb
@@ -28,14 +28,6 @@ require 'cloudware/models'
 require 'cloudware/providers/base'
 
 RSpec.describe Cloudware::Models::Deployment do
-  shared_examples 'deploy raises ModelValidationError' do
-    it 'raises ModelValidationError' do
-      expect do
-        subject.deploy
-      end.to raise_error(Cloudware::ModelValidationError)
-    end
-  end
-
   subject do
     build(:deployment, replacements: replacements).tap do |deployment|
       Cloudware::Models::Cluster.create_or_update(deployment.cluster)
@@ -72,12 +64,6 @@ RSpec.describe Cloudware::Models::Deployment do
     end
   end
 
-  context 'without a template' do
-    describe '#deploy' do
-      include_examples 'deploy raises ModelValidationError'
-    end
-  end
-
   context 'with an existing template' do
     before do
       path = subject.send(:template_path)
@@ -99,20 +85,6 @@ RSpec.describe Cloudware::Models::Deployment do
           subject.deploy
           expect(subject.deployment_error).to be_nil
         end
-
-        context 'without a cluster' do
-          before do
-            allow(subject).to receive(:cluster).and_return(nil)
-          end
-
-          include_examples 'deploy raises ModelValidationError'
-        end
-      end
-
-      context 'with a replacement tag' do
-        let(:template_content) { '%unreplaced-tag%' }
-
-        it_behaves_like 'deploy raises ModelValidationError'
       end
     end
 


### PR DESCRIPTION
The `destroy` command has been changed to only tearing down the remote resources. The `Deployment` is not deleted, but instead updated to be "offline" (`deployed: false`).

This allows it to be redeployed latter using the `deploy` command. Calling `deploy` with a single argument will deploy and existing deployment. The second TEMPLATE input will trigger a deployment to be created with that template.

Finally, an "offline" deployment can be permanently removed using the `delete` command.